### PR TITLE
fix: update gh-bugcop to use actual issue labels and disable dry run

### DIFF
--- a/app/(dashboard)/getTotalsData.tsx
+++ b/app/(dashboard)/getTotalsData.tsx
@@ -2,10 +2,10 @@
 import { $pipeline } from "@/packages/mongodb-pipeline-ts/$pipeline";
 import { Totals } from "@/src/Totals";
 import { flatten } from "flat";
-import sf from "sflow";
+import { sflow } from "sflow";
 
 export async function getTotalsData() {
-  return sf(
+  return sflow(
     $pipeline(Totals)
       .match({ "totals.data": { $exists: true } })
       .match({ "totals.mtime": { $gt: new Date(+new Date() - 86400e3 * 30) } }) // 1 month

--- a/app/tasks/gh-bugcop/GithubBugcopTaskStatus.tsx
+++ b/app/tasks/gh-bugcop/GithubBugcopTaskStatus.tsx
@@ -14,6 +14,33 @@ export default function GithubBugcopTaskStatus({}) {
   const [data, setData] = useState<WithId<GithubBugcopTask>[]>([]);
   const [logs, setLogs] = useState<string[]>([]);
 
+  // Color mappers
+  const getStatusColor = (labels?: string[]) => {
+    if (labels?.includes(ASKING_LABEL)) return "yellow";
+    if (labels?.includes(ANSWERED_LABEL)) return "green";
+    return "red";
+  };
+
+  const taskStatusColorMap: Record<string, string> = {
+    responseReceived: "green",
+    askForInfo: "yellow",
+  };
+
+  const taskActionColorMap: Record<string, string> = {
+    ok: "green",
+    processing: "yellow",
+    error: "red",
+  };
+
+  const getUpdatedAtColor = (updatedAt?: Date) => {
+    if (!updatedAt) return "gray";
+    const daysSince = (Date.now() - updatedAt.getTime()) / (1000 * 60 * 60 * 24);
+    if (daysSince < 3) return "green";
+    if (daysSince < 7) return "yellow";
+    if (daysSince < 15) return "red";
+    return "gray";
+  };
+
   useAsyncEffect(async () => {
     const ac = new AbortController();
     // init query
@@ -79,23 +106,9 @@ export default function GithubBugcopTaskStatus({}) {
 
       <Text color="blue">Status:</Text>
       {data.map((task) => {
-        const statusColor = task.labels?.includes(ASKING_LABEL)
-          ? "yellow"
-          : task.labels?.includes(ANSWERED_LABEL)
-            ? "green"
-            : "red";
-
-        // Status colors
-        const taskStatusColor =
-          task.status === "responseReceived" ? "green" : task.status === "askForInfo" ? "yellow" : "red";
-        const taskActionColor =
-          task.taskStatus === "ok"
-            ? "green"
-            : task.taskStatus === "processing"
-              ? "yellow"
-              : task.taskStatus === "error"
-                ? "red"
-                : "gray";
+        const statusColor = getStatusColor(task.labels);
+        const taskStatusColor = taskStatusColorMap[task.status ?? ""] ?? "red";
+        const taskActionColor = taskActionColorMap[task.taskStatus ?? ""] ?? "gray";
 
         return (
           <Box key={task.url} flexDirection="column">
@@ -113,16 +126,7 @@ export default function GithubBugcopTaskStatus({}) {
               </Box>
               <Box flexDirection="row">
                 <Text> ├─ Updated at: </Text>
-                <Text
-                  color={(() => {
-                    if (!task.updatedAt) return "gray";
-                    const daysSince = (Date.now() - new Date(task.updatedAt).getTime()) / (1000 * 60 * 60 * 24);
-                    if (daysSince < 3) return "green";
-                    if (daysSince < 7) return "yellow";
-                    if (daysSince < 15) return "red";
-                    return "gray";
-                  })()}
-                >
+                <Text color={getUpdatedAtColor(task.updatedAt)}>
                   {task.updatedAt
                     ? prettyMilliseconds(Date.now() - new Date(task.updatedAt).getTime()) + " ago"
                     : "never"}

--- a/app/tasks/gh-bugcop/GithubBugcopTaskStatus.tsx
+++ b/app/tasks/gh-bugcop/GithubBugcopTaskStatus.tsx
@@ -87,7 +87,7 @@ export default function GithubBugcopTaskStatus({}) {
 
         // Status colors
         const taskStatusColor =
-          task.status === "answered" ? "green" : task.status === "ask-for-info" ? "yellow" : "red";
+          task.status === "responseReceived" ? "green" : task.status === "askForInfo" ? "yellow" : "red";
         const taskActionColor =
           task.taskStatus === "ok"
             ? "green"

--- a/app/tasks/gh-bugcop/gh-bugcop.tsx
+++ b/app/tasks/gh-bugcop/gh-bugcop.tsx
@@ -217,7 +217,7 @@ async function processIssue(issue: GH["issue"]) {
       .filter((e) => e.user) // filter out comments without user
       .filter((e) => !e.user?.login.match(/\[bot\]$|-bot/)) // no bots
       .filter((e) => !["COLLABORATOR", "CONTRIBUTOR", "MEMBER", "OWNER"].includes(e.author_association)) // not by collaborators, usually askForInfo for more info
-      .filter((e) => e.user!.login !== latestLabeledEvent.actor.login) // ignore the user who added the label
+      .filter((e) => e.user?.login !== latestLabeledEvent.actor.login) // ignore the user who added the label
       .filter((e) => +new Date(e.updated_at) > +new Date(labelLastAddedTime)) // only comments that is updated later than the label added time
       .toArray();
     newComments.length && tlog("Found " + newComments.length + " comments after last added time for " + issue.html_url);

--- a/app/tasks/gh-bugcop/gh-bugcop.tsx
+++ b/app/tasks/gh-bugcop/gh-bugcop.tsx
@@ -13,7 +13,6 @@ import hotMemo from "hot-memo";
 import isCI from "is-ci";
 import { difference, union } from "rambda";
 import sflow, { pageFlow } from "sflow";
-import { match } from "ts-pattern";
 import z from "zod";
 import { createTimeLogger } from "../gh-design/createTimeLogger";
 // import Lock from 'async-sema';
@@ -35,7 +34,12 @@ export const GithubBugcopTaskDefaultMeta = {
 export type GithubBugcopTask = {
   url: string; // the issue URL
 
-  status?: "ask-for-info" | "answered" | "closed";
+  status?: // | "ask-for-info" // deprecated, use "askForInfo" instead, this may still in db
+  // | "answered"  // deprecated, use "responseReceived" instead, this may still in db
+
+  | "askForInfo" // user has not answered yet, but we have ask-for-info label
+    | "responseReceived" // user has answered the issue, so we can remove the askForInfo
+    | "closed"; // issue is closed, so we can remove all bug-cop labels
   statusReason?: string; // reason for the status, for example, "no new comments" or "body updated"
   updatedAt?: Date; // the last updated time of the issue, for diff checking
 
@@ -58,6 +62,7 @@ export const GithubBugcopTaskMeta = TaskMetaCollection("GithubBugcopTask", zGith
 export const GithubBugcopTask = db.collection<GithubBugcopTask>("GithubBugcopTask");
 
 const tlog = createTimeLogger();
+const isDryRun = process.env.DRY_RUN === "true" || process.argv.slice(2).includes("--dry");
 
 if (import.meta.main) {
   await runGithubBugcopTask();
@@ -68,12 +73,11 @@ if (import.meta.main) {
 }
 
 export default async function runGithubBugcopTask() {
-  const isDryRun = process.env.DRY_RUN === "true" || process.argv.slice(2).includes("--dry");
   tlog("Running Github Bugcop Task...");
-  await sflow(REPOLIST)
+  const openningIssues = await sflow(REPOLIST)
     // list issues for each repo
     .map((repoUrl) => {
-      // tlog(`Fetching issues for ${url}...`);
+      tlog(`Fetching issues for ${repoUrl}...`);
       return pageFlow(1, async (page) => {
         const { data: issues } = await hotMemo(gh.issues.listForRepo, [
           {
@@ -86,220 +90,186 @@ export default async function runGithubBugcopTask() {
         ]);
         tlog(`Found ${issues.length} matched issues in ${repoUrl}`);
         return { data: issues, next: issues.length >= 100 ? page + 1 : undefined };
-      })
-        .filter((e) => e.length)
-        .flat();
-      // .by(flats());
+      }).flat();
     })
-    .confluenceByParallel() // order does not matter, so we can run in parallel
-    // .by((issueFlow) => {
-    //   const tr = new TransformStream<GH["issue"], GH["issue"]>();
-    //   const writer = tr.writable.getWriter();
-    //   //
-    //   issueFlow
-    //     // pipe downstream, but do not close the writer so that we can write to it later
-    //     .forkTo((s) => s.forEach((issue) => writer.write(issue)).run())
-    //     // collect all scanned issues in an array
-    //     .toArray()
-    //     // once a full scan for all repos is done
-    //     // there might be a few issues that are not in the list
-    //     // e.g. recently closed issue, will not be found in the list since we are filtering by "open" issues
-    //     // but they are still in db, as they were opened before the scan started
-    //     // so we need to update it
-    //     .then(async (openingIssues) => {
-    //       // const scannedUrls = openingIssues.map((i) => i.html_url);
-    //       // await sflow(GithubBugcopTask.find({ url: { $nin: scannedUrls } }, { projection: { url: 1 } }))
-    //       //   .map((e) => e as { url: string })
-    //       //   .map(async ({ url }) => await gh.issues.get({ ...parseIssueUrl(url) }))
-    //       //   .map((e) => e.data)
-    //       //   .forEach((issue) => writer.write(issue))
-    //       //   .run();
-    //       // await writer.close();
-    //     });
-    //   return tr.readable;
-    // })
-    .uniqBy((issue) => issue.html_url) // remove duplicates by issue URL, maybe not necessary, but good for redability
-    .map(async function processIssue(issue) {
-      const url = issue.html_url; // ?? ("issue.html_url is required")    ;
-      const issueId = parseIssueUrl(issue.html_url); // = {owner, repo, issue_number}
-      let task = await GithubBugcopTask.findOne({ url });
-      const saveTask = async (data: Partial<GithubBugcopTask>) =>
-        (task =
-          (await GithubBugcopTask.findOneAndUpdate(
-            { url },
-            { $set: data },
-            { returnDocument: "after", upsert: true },
-          )) || DIE("never"));
-      task = await saveTask({
-        taskStatus: "processing",
-        user: issue.user?.login,
-        labels: issue.labels.map((l) => (typeof l === "string" ? l : (l.name ?? ""))).filter(Boolean),
-        updatedAt: new Date(issue.updated_at),
-      });
+    .confluenceByParallel() // unpack pageFlow, order does not matter, so we can run in parallel
+    .forEach(processIssue)
+    .toArray();
 
-      if (issue.state === "closed") {
-        await saveTask({
-          status: "closed",
-          statusReason: "issue closed",
-          updatedAt: new Date(issue.updated_at),
-          lastChecked: new Date(),
-        });
-        return;
-      }
+  tlog(`Processed ${openningIssues.length} open issues with label "${ASKING_LABEL}"`);
 
-      if (!task.labels?.includes(ASKING_LABEL)) {
-        await saveTask({ updatedAt: new Date(issue.updated_at), labels: [...(task.labels ?? []), ASKING_LABEL] });
-      }
-
-      // check if the issue body is updated since last successful scan
-      if (!task.body) await saveTask({ body: issue.body ?? undefined });
-      const isBodyAddedContent =
-        issue.body &&
-        task.body &&
-        issue.body !== task.body &&
-        fastDiff(task.body ?? "", issue.body ?? "").filter(([op, val]) => op === fastDiff.INSERT).length > 0; // check if the issue body has added new content after the label added time
-
-      tlog(chalk.bgBlackBright("Issue: " + issue.html_url));
-
-      const timeline = await pageFlow(1, async (page) => {
-        const { data: events } = await hotMemo(gh.issues.listEventsForTimeline, [
-          {
-            ...issueId,
-            page,
-            per_page: 100,
-          },
-        ]);
-        return { data: events, next: events.length >= 100 ? page + 1 : undefined };
-      })
-        // flat
-        .filter((e) => e.length)
-        .by((s) => s.pipeThrough(flats()))
-        .toArray();
-
-      // list all label events
-      const labelEvents = await sflow([...timeline])
-        .forEach((_e) => {
-          if (_e.event === "labeled") {
-            const e = _e as GH["labeled-issue-event"];
-            tlog(`#${issue.number} ${new Date(e.created_at).toISOString()} @${e.actor.login} + label:${e.label.name}`);
-            return e;
-          }
-          if (_e.event === "unlabeled") {
-            const e = _e as GH["unlabeled-issue-event"];
-            tlog(`#${issue.number} ${new Date(e.created_at).toISOString()} @${e.actor.login} - label:${e.label.name}`);
-            return e;
-          }
-          if (_e.event === "commented") {
-            const e = _e as GH["timeline-comment-event"];
-            tlog(`#${issue.number} ${new Date(e.created_at).toISOString()} @${e.actor?.login} ${e.body?.slice(0, 20)}`);
-            return e;
-          }
-
-          tlog(`#${issue.number} ${new Date((_e as any).created_at ?? new Date()).toISOString()} ? ${_e.event}`);
-          // ignore other events
-        })
-        .toArray();
-      tlog("Found " + labelEvents.length + " timeline events");
-      await saveTask({ timeline: labelEvents as any });
-
-      const latestLabeledEvent =
-        labelEvents
-          .filter((e) => e.event === "labeled")
-          .map((e) => e as GH["labeled-issue-event"])
-          .filter((e) => e.label?.name === ASKING_LABEL)
-          .sort(compareBy((e) => e.created_at))
-          .reverse()[0] ||
-        DIE("No labeled event found, this should not happen since we are filtering issues by this label");
-      // last added time of this label
-      const labelLastAddedTime = new Date(latestLabeledEvent?.created_at);
-      tlog('Last added time of label "' + ASKING_LABEL + '" is ' + labelLastAddedTime.toISOString());
-
-      // checkif it's answered
-      const hasNewComment = await (async function () {
-        // 1. list issue comments that is updated/created later than this label last added
-        const comments = await pageFlow(1, async (page) => {
-          const { data: comments } = await hotMemo(gh.issues.listComments.bind(gh.issues), [
-            { ...issueId, page, per_page: 100 },
-          ]);
-          return { data: comments, next: comments.length >= 100 ? page + 1 : undefined };
-        })
-          .filter((page) => page.length)
-          .flat()
-          .filter((e) => e.user) // filter out comments without user
-          .filter((e) => !e.user!.login.match(/\[bot\]$|-bot/)) // no bots
-          .filter((e) => e.user!.login !== latestLabeledEvent.actor.login) // ignore the user who added the label
-          .filter((e) => +new Date(e.updated_at) > +new Date(labelLastAddedTime)) // only comments that is updated later than the label added time
-          .toArray();
-        tlog("Found " + comments.length + " comments after last added time for " + issue.html_url);
-        tlog("Found " + JSON.stringify(comments));
-        return !!comments.length;
-      })();
-
-      // // TODO: maybe search in notion db about this issue, if it's answered in notion, then mark as answered
-      // tlog('issue body not updated after last added time, checking comments...');
-
-      const responseReceived = hasNewComment || isBodyAddedContent; // check if user responsed info by new comment or body update
-      const status: "responseReceived" | "asking" = responseReceived ? "responseReceived" : "asking";
-
-      return await match(status)
-        .with("responseReceived", async () => {
-          tlog(
-            chalk.bgBlue(
-              `Issue ${url} is answered by user, removing ask-for-info and answered labels, adding response-received label...`,
-            ),
-          );
-          task = await saveTask({
-            status: "answered",
-            statusReason: isBodyAddedContent ? "body updated" : hasNewComment ? "new comment" : "unknown",
-          });
-
-          if (isDryRun) return;
-
-          task = await saveTask({
-            taskAction: "- " + ASKING_LABEL + ", - " + ANSWERED_LABEL + ", + " + RESPONSE_RECEIVED_LABEL,
-          });
-          // Remove both ask-for-info and answered labels when user has answered
-          if (task.labels?.includes(ASKING_LABEL)) await gh.issues.removeLabel({ ...issueId, name: ASKING_LABEL });
-          if (task.labels?.includes(ANSWERED_LABEL)) await gh.issues.removeLabel({ ...issueId, name: ANSWERED_LABEL });
-          task.labels = difference(task.labels || [], [ASKING_LABEL, ANSWERED_LABEL]);
-
-          // Add response-received label
-          if (!task.labels?.includes(RESPONSE_RECEIVED_LABEL))
-            await gh.issues.addLabels({ ...issueId, labels: [RESPONSE_RECEIVED_LABEL] });
-          task.labels = union(task.labels || [], [RESPONSE_RECEIVED_LABEL]);
-
-          task = await saveTask({ labels: task.labels });
-
-          tlog(
-            'Removed "bug-cop:ask-for-info" and "bug-cop:answered" labels, added "bug-cop:response-received" label to ' +
-              issue.html_url,
-          );
-          await saveTask({ body: issue.body ?? undefined });
-        })
-        .with("asking", async () => {
-          tlog(chalk.bgYellow(`Issue ${url} is still asking for info, updating task status...`));
-
-          // User hasn't answered yet, but we have ask-for-info label
-          task = await saveTask({ status: "ask-for-info", statusReason: "user not answered yet" });
-
-          if (isDryRun) return;
-
-          if (!task.labels?.includes(ANSWERED_LABEL))
-            await gh.issues.addLabels({ ...issueId, labels: [ANSWERED_LABEL] });
-          task.labels = union(task.labels || [], [ANSWERED_LABEL]);
-
-          if (task.labels?.includes(RESPONSE_RECEIVED_LABEL))
-            await gh.issues.removeLabel({ ...issueId, name: RESPONSE_RECEIVED_LABEL });
-          task.labels = difference(task.labels || [], [RESPONSE_RECEIVED_LABEL]);
-
-          task = await saveTask({ lastChecked: new Date(), taskStatus: "ok", labels: task.labels });
-        })
-        .exhaustive();
-    })
+  // once openning issues are processed,
+  // now we should process the issues in db that's not openning anymore
+  await sflow(
+    GithubBugcopTask.find({
+      url: { $nin: openningIssues.map((e) => e.html_url) },
+    }),
+  )
+    .map((task) => task.url)
+    .log()
+    .map(async (issueUrl) => await hotMemo(gh.issues.get, [{ ...parseIssueUrl(issueUrl) }]).then((e) => e.data))
+    // .log()
+    .forEach(processIssue)
     .run();
+
   tlog(chalk.green("Github Bugcop Task completed successfully!"));
 }
 
+async function processIssue(issue: GH["issue"]) {
+  const url = issue.html_url; // ?? ("issue.html_url is required")    ;
+  const issueId = parseIssueUrl(issue.html_url); // = {owner, repo, issue_number}
+  let task = await GithubBugcopTask.findOne({ url });
+  const saveTask = async (data: Partial<GithubBugcopTask>) =>
+    (task =
+      (await GithubBugcopTask.findOneAndUpdate({ url }, { $set: data }, { returnDocument: "after", upsert: true })) ||
+      DIE("never"));
+  task = await saveTask({
+    taskStatus: "processing",
+    user: issue.user?.login,
+    labels: issue.labels.map((l) => (typeof l === "string" ? l : (l.name ?? ""))).filter(Boolean),
+    updatedAt: new Date(issue.updated_at),
+  });
+
+  if (issue.state === "closed") {
+    await saveTask({
+      status: "closed",
+      statusReason: "issue closed",
+      updatedAt: new Date(issue.updated_at),
+      lastChecked: new Date(),
+    });
+    return;
+  }
+
+  // check if the issue body is updated since last successful scan
+  if (!task.body) await saveTask({ body: issue.body ?? undefined });
+  const isBodyAddedContent =
+    issue.body &&
+    task.body &&
+    issue.body !== task.body &&
+    fastDiff(task.body ?? "", issue.body ?? "").filter(([op, val]) => op === fastDiff.INSERT).length > 0; // check if the issue body has added new content after the label added time
+
+  tlog(chalk.bgBlackBright("Issue: " + issue.html_url));
+
+  const timeline = await pageFlow(1, async (page) => {
+    const { data: events } = await hotMemo(gh.issues.listEventsForTimeline, [
+      {
+        ...issueId,
+        page,
+        per_page: 100,
+      },
+    ]);
+    return { data: events, next: events.length >= 100 ? page + 1 : undefined };
+  })
+    // flat
+    .filter((e) => e.length)
+    .by((s) => s.pipeThrough(flats()))
+    .toArray();
+
+  // list all label events
+  const labelEvents = await sflow([...timeline])
+    .forEach((_e) => {
+      if (_e.event === "labeled") {
+        const e = _e as GH["labeled-issue-event"];
+        // tlog(`#${issue.number} ${new Date(e.created_at).toISOString()} @${e.actor.login} + label:${e.label.name}`);
+        return e;
+      }
+      if (_e.event === "unlabeled") {
+        const e = _e as GH["unlabeled-issue-event"];
+        // tlog(`#${issue.number} ${new Date(e.created_at).toISOString()} @${e.actor.login} - label:${e.label.name}`);
+        return e;
+      }
+      if (_e.event === "commented") {
+        const e = _e as GH["timeline-comment-event"];
+        // tlog(`#${issue.number} ${new Date(e.created_at).toISOString()} @${e.actor?.login} ${e.body?.slice(0, 20)}`);
+        return e;
+      }
+
+      tlog(`#${issue.number} ${new Date((_e as any).created_at ?? new Date()).toISOString()} ? ${_e.event}`);
+      // ignore other events
+    })
+    .toArray();
+  // tlog("Found " + labelEvents.length + " timeline events");
+  await saveTask({ timeline: labelEvents as any });
+
+  const latestLabeledEvent =
+    labelEvents
+      .filter((e) => e.event === "labeled")
+      .map((e) => e as GH["labeled-issue-event"])
+      .filter((e) => e.label?.name === ASKING_LABEL)
+      .sort(compareBy((e) => e.created_at))
+      .reverse()[0] ||
+    DIE("No labeled event found, this should not happen since we are filtering issues by this label");
+  // last added time of this label
+  const labelLastAddedTime = new Date(latestLabeledEvent?.created_at);
+  tlog('Last added time of label "' + ASKING_LABEL + '" is ' + labelLastAddedTime.toISOString());
+
+  // checkif it's answered
+  const hasNewComment = await (async function () {
+    // 1. list issue comments that is updated/created later than this label last added
+    const newComments = await pageFlow(1, async (page) => {
+      const { data: comments } = await hotMemo(gh.issues.listComments.bind(gh.issues), [
+        { ...issueId, page, per_page: 100 },
+      ]);
+      return { data: comments, next: comments.length >= 100 ? page + 1 : undefined };
+    })
+      .filter((page) => page.length)
+      .flat()
+      .filter((e) => e.user) // filter out comments without user
+      .filter((e) => !e.user!.login.match(/\[bot\]$|-bot/)) // no bots
+      .filter((e) => !["COLLABORATOR", "CONTRIBUTOR", "MEMBER", "OWNER"].includes(e.author_association)) // not by collaborators, usually askForInfo for more info
+      .filter((e) => e.user!.login !== latestLabeledEvent.actor.login) // ignore the user who added the label
+      .filter((e) => +new Date(e.updated_at) > +new Date(labelLastAddedTime)) // only comments that is updated later than the label added time
+      .toArray();
+    newComments.length && tlog("Found " + newComments.length + " comments after last added time for " + issue.html_url);
+    // tlog("Found " + JSON.stringify(comments));
+    return !!newComments.length;
+  })();
+
+  // TODO: maybe search in notion db about this issue, if it's answered in notion, then mark as answered
+  // tlog('issue body not updated after last added time, checking comments...');
+
+  const responseReceived = hasNewComment || isBodyAddedContent; // check if user responsed info by new comment or body update
+  const status: "responseReceived" | "askForInfo" = responseReceived ? "responseReceived" : "askForInfo";
+  const workinglabels = [ASKING_LABEL, ANSWERED_LABEL, RESPONSE_RECEIVED_LABEL];
+  const labelSet = {
+    responseReceived: [RESPONSE_RECEIVED_LABEL],
+    askForInfo: [ANSWERED_LABEL, ASKING_LABEL],
+    closed: [], // clear bug-cop labels
+  }[status];
+
+  const currentLabels = issue.labels.map((l) => (typeof l === "string" ? l : (l.name ?? ""))).filter(Boolean);
+  const addLabels = difference(labelSet, currentLabels);
+  const removeLabels = difference(
+    currentLabels.filter((label) => workinglabels.includes(label)),
+    labelSet,
+  );
+
+  tlog(`Issue ${issue.html_url}`);
+  tlog(
+    `>> status: ${status}, labels: ${chalk.bgBlue([...addLabels.map((e) => "+ " + e), ...removeLabels.map((e) => "- " + e)].join(", "))}`,
+  );
+
+  if (isDryRun) return;
+
+  await sflow(addLabels)
+    .forEach((label) => tlog(`Adding label ${label} to ${issue.html_url}`))
+    .map((label) => gh.issues.addLabels({ ...issueId, labels: [label] }))
+    .run();
+  await sflow(removeLabels)
+    .forEach((label) => tlog(`Removing label ${label} from ${issue.html_url}`))
+    .map((label) => gh.issues.removeLabel({ ...issueId, name: label }))
+    .run();
+
+  // update task status
+  await saveTask({
+    status,
+    statusReason: isBodyAddedContent ? "body updated" : hasNewComment ? "new comment" : "unknown",
+    taskStatus: "ok",
+    taskAction: [...addLabels.map((e) => "+ " + e), ...removeLabels.map((e) => "- " + e)].join(", "),
+    lastChecked: new Date(),
+    labels: union(task.labels || [], addLabels).filter((e) => !removeLabels.includes(e)),
+  });
+}
 function flats<T>(): TransformStream<T[], T> {
   return new TransformStream<T[], T>({
     transform: (e, controller) => {

--- a/bun.lock
+++ b/bun.lock
@@ -83,7 +83,7 @@
         "react-intersection-observer": "^9.16.0",
         "react-markdown": "^9.0.1",
         "remark-gfm": "^4.0.0",
-        "sflow": "1.21",
+        "sflow": "^1.24.0",
         "sha256": "^0.2.0",
         "sparse-bitfield": "^3.0.3",
         "swr": "^2.3.4",
@@ -2062,7 +2062,7 @@
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
-    "sflow": ["sflow@1.21.0", "", { "dependencies": { "@types/d3": "^7.4.3", "bson": "^6.8.0", "d3": "^7.9.0", "from-node-stream": "0.0.4", "phpdie": "^1.2.12", "polyfill-text-decoder-stream": "0.0.10", "polyfill-text-encoder-stream": "^0.0.9", "rambda": "^9.2.1", "string-replace-async": "^3.0.2", "ts-essentials": "^10.1.1", "unwind-array": "^1.1.4", "web-streams-extensions": "^0.12.0" }, "peerDependencies": { "react-hook-form": "^7.52.2", "typescript": "^5.0.0" } }, "sha512-kTwz4COf+LkTe4ZeeDELopqYkvqL4G86fy7MLHlRpbzbO6aU0ALJFChzOrF01W9kPQfyrlxtl3yklYlJSgXQJQ=="],
+    "sflow": ["sflow@1.24.0", "", { "dependencies": { "@types/d3": "^7.4.3", "bson": "^6.8.0", "d3": "^7.9.0", "from-node-stream": "0.0.4", "phpdie": "^1.2.12", "polyfill-text-decoder-stream": "0.0.10", "polyfill-text-encoder-stream": "^0.0.9", "rambda": "^9.2.1", "string-replace-async": "^3.0.2", "ts-essentials": "^10.1.1", "unwind-array": "^1.1.4", "web-streams-extensions": "^0.12.0" }, "peerDependencies": { "react-hook-form": "^7.52.2", "typescript": "^5.0.0" } }, "sha512-P1fX/eSg3ynHybGk7JQX1dHEsFkVf5t5Qw2FueKKqZeQqGAJEwXgHAOQIWO6kJFu2gxyiRWGQoGQhmbrxu7Ycg=="],
 
     "sha256": ["sha256@0.2.0", "", { "dependencies": { "convert-hex": "~0.1.0", "convert-string": "~0.1.0" } }, "sha512-kTWMJUaez5iiT9CcMv8jSq6kMhw3ST0uRdcIWl3D77s6AsLXNXRp3heeqqfu5+Dyfu4hwpQnMzhqHh8iNQxw0w=="],
 

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "react-intersection-observer": "^9.16.0",
     "react-markdown": "^9.0.1",
     "remark-gfm": "^4.0.0",
-    "sflow": "1.21",
+    "sflow": "^1.24.0",
     "sha256": "^0.2.0",
     "sparse-bitfield": "^3.0.3",
     "swr": "^2.3.4",

--- a/src/CRNodes.ts
+++ b/src/CRNodes.ts
@@ -17,11 +17,13 @@ await CRNodes.createIndex({ repository: 1 }, { unique: false }); // WARN: duplic
 
 if (import.meta.main) {
   // peek cr nodes
-  const r = await sf(
-    $pipeline(CNRepos)
-      .match({ cr: { $exists: true } })
-      .replaceRoot({ newRoot: "$cr" })
-      .aggregate(),
-  ).toArray();
+  const r = await sf
+    .sflow(
+      $pipeline(CNRepos)
+        .match({ cr: { $exists: true } })
+        .replaceRoot({ newRoot: "$cr" })
+        .aggregate(),
+    )
+    .toArray();
   peekYaml({ r, len: r.length });
 }

--- a/src/EmailTasks.ts
+++ b/src/EmailTasks.ts
@@ -25,10 +25,10 @@ export const EmailTasks = db.collection<EmailTask>("EmailTasks");
 await EmailTasks.createIndex({ from: 1, to: 1, subject: 1 });
 
 if (import.meta.main) {
-  sf(EmailTasks.find({}))
+  sf.sflow(EmailTasks.find({}))
     .map((e) => e.state)
     .toLog();
-  // sf(EmailTasks.watch([], { fullDocument: "whenAvailable" }))
+  // sf.sflow(EmailTasks.watch([], { fullDocument: "whenAvailable" }))
   //   // .filter((c) => c.operationType === "modify")
   //   .toLog()
   //   .then(() => console.log("all done"));
@@ -64,8 +64,9 @@ export async function enqueueEmailTask(task: z.infer<typeof zSendEmailAction>) {
   );
 }
 export async function updateEmailTasks() {
-  const count = await sf(EmailTasks.find({ state: "waiting" }))
-    .merge(sf(EmailTasks.find({ state: "sending", mtime: $stale("1m") })))
+  const count = await sf
+    .sflow(EmailTasks.find({ state: "waiting" }))
+    .merge(sf.sflow(EmailTasks.find({ state: "sending", mtime: $stale("1m") })))
     .map(async (e) => {
       const { _id, state } = e;
       if (state === "waiting") {

--- a/src/Totals.ts
+++ b/src/Totals.ts
@@ -12,13 +12,14 @@ export const Totals = db.collection<{
   totals?: Task<Totals>;
 }>("Totals");
 if (import.meta.main) {
-  sf(
-    $pipeline(Totals)
-      .match({ "totals.data": { $exists: true } })
-      .set({ "totals.data.date": "$totals.mtime" })
-      .replaceRoot({ newRoot: "$totals.data" })
-      .aggregate(),
-  )
+  await sf
+    .sflow(
+      $pipeline(Totals)
+        .match({ "totals.data": { $exists: true } })
+        .set({ "totals.data.date": "$totals.mtime" })
+        .replaceRoot({ newRoot: "$totals.data" })
+        .aggregate(),
+    )
     .map((e) => flatten(e) as { date: string } & Record<string, number>)
     .toLog();
 }

--- a/src/check/security-scan.spec.ts
+++ b/src/check/security-scan.spec.ts
@@ -25,41 +25,42 @@ it.skip("works", async () => {
   console.log("all:", all.length);
   const ai = new OpenAI();
 
-  await sf(
-    await ai.chat.completions
-      .create({
-        model: "gpt-4o",
-        tools: [
-          {
-            function: {
-              name: "scan-file",
-              description: "scan file",
-              parameters: {
-                type: "object",
-                properties: {
-                  file: {
-                    type: "string",
-                    description: "The file to scan",
+  await sf
+    .sflow(
+      await ai.chat.completions
+        .create({
+          model: "gpt-4o",
+          tools: [
+            {
+              function: {
+                name: "scan-file",
+                description: "scan file",
+                parameters: {
+                  type: "object",
+                  properties: {
+                    file: {
+                      type: "string",
+                      description: "The file to scan",
+                    },
+                    // unit: { type: "string", enum: ["celsius", "fahrenheit"] },
                   },
-                  // unit: { type: "string", enum: ["celsius", "fahrenheit"] },
+                  required: ["file"],
                 },
-                required: ["file"],
               },
+              type: "function",
             },
-            type: "function",
-          },
-        ],
-        messages: [
-          {
-            role: "system",
-            content:
-              "Act as a code-security-scanner, tell me problems in the codes below: \n\n" + all.slice(0, 1024 * 80),
-          },
-        ],
-        stream: true,
-      })
-      .then((e) => e.toReadableStream()),
-  )
+          ],
+          messages: [
+            {
+              role: "system",
+              content:
+                "Act as a code-security-scanner, tell me problems in the codes below: \n\n" + all.slice(0, 1024 * 80),
+            },
+          ],
+          stream: true,
+        })
+        .then((e) => e.toReadableStream()),
+    )
     .through(new PolyfillTextDecoderStream())
     .map((e) => JSON.parse(e).choices[0].delta.content ?? "")
     .tees(fromWritable(createWriteStream(resultmd)))

--- a/src/gcloud/GCloudOAuth2Credentials.ts
+++ b/src/gcloud/GCloudOAuth2Credentials.ts
@@ -15,13 +15,15 @@ export const GCloudOAuth2Credentials = db.collection<{
 export type RedirectFn = (url: string) => Awaitable<never>;
 if (import.meta.main) {
   // await GCloudOAuth2Credentials.drop()
-  await sf(
-    GCloudOAuth2Credentials.find({
-      scopes: {
-        $all: ["https://www.googleapis.com/auth/gmail.compose", "https://www.googleapis.com/auth/userinfo.email"],
-      },
-    }),
-  ).toLog();
+  await sf
+    .sflow(
+      GCloudOAuth2Credentials.find({
+        scopes: {
+          $all: ["https://www.googleapis.com/auth/gmail.compose", "https://www.googleapis.com/auth/userinfo.email"],
+        },
+      }),
+    )
+    .toLog();
 }
 /**
  * Get an scope authenticated GCloud OAuth2 Client (cached in db.GCloudOAuth2Credentials)


### PR DESCRIPTION
## Summary
- Fix label comparison to use current issue labels instead of task labels for proper bug-cop workflow
- Remove hardcoded dry run override to respect DRY_RUN environment variable  
- Update sflow dependency to version 1.24.0

## Test plan
- [x] Verify bug-cop task correctly compares against actual GitHub issue labels
- [ ] Confirm dry run mode can be controlled via environment variable
- [ ] Test label addition/removal functionality works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)