### PR TITLE
Remove ANSWERED_LABEL management from bug-cop

### DIFF
--- a/app/tasks/gh-bugcop/GithubBugcopTaskStatus.tsx
+++ b/app/tasks/gh-bugcop/GithubBugcopTaskStatus.tsx
@@ -5,7 +5,7 @@ import prettyMilliseconds from "pretty-ms";
 import { useEffect, useState } from "react";
 import sflow from "sflow";
 import useAsyncEffect from "use-async-effect";
-import { ANSWERED_LABEL, ASKING_LABEL, GithubBugcopTask } from "./gh-bugcop";
+import { ASKING_LABEL, GithubBugcopTask } from "./gh-bugcop";
 
 if (import.meta.main) render(<GithubBugcopTaskStatus />);
 
@@ -17,7 +17,7 @@ export default function GithubBugcopTaskStatus({}) {
   // Color mappers
   const getStatusColor = (labels?: string[]) => {
     if (labels?.includes(ASKING_LABEL)) return "yellow";
-    if (labels?.includes(ANSWERED_LABEL)) return "green";
+    // if (labels?.includes(ANSWERED_LABEL)) return "green";
     return "red";
   };
 

--- a/app/tasks/gh-bugcop/gh-bugcop.tsx
+++ b/app/tasks/gh-bugcop/gh-bugcop.tsx
@@ -29,7 +29,7 @@ export const REPOLIST = [
   "https://github.com/Comfy-Org/desktop",
 ];
 export const ASKING_LABEL = "bug-cop:ask-for-info";
-// export const ANSWERED_LABEL = "bug-cop:answered"; // never managed by bot
+// export const ANSWERED_LABEL = "bug-cop:answered"; // 2025-08-09 “answered” is never managed by bot
 export const RESPONSE_RECEIVED_LABEL = "bug-cop:response-received";
 export const GithubBugcopTaskDefaultMeta = {
   repoUrls: REPOLIST,

--- a/app/tasks/gh-bugcop/gh-bugcop.tsx
+++ b/app/tasks/gh-bugcop/gh-bugcop.tsx
@@ -1,7 +1,8 @@
 /**
  * Github Bugcop Bot
+ * 1. bot matches issues for label "bug-cop:ask-for-info"
+ * 2. if user have added context, remove "bug-cop:ask-for-info" and add "bug-cop:response-received"
  */
-// 1. bot matches label "bug-cop:ask-for-info", and if user have added context, remove "bug-cop:ask-for-info" and add "bug-cop:response-received"
 
 // for repo
 import { db } from "@/src/db";

--- a/app/tasks/gh-bugcop/gh-bugcop.tsx
+++ b/app/tasks/gh-bugcop/gh-bugcop.tsx
@@ -1,4 +1,8 @@
-// 1. bot matches label "bug-cop:ask-for-info", and if user have added context, remove "bug-cop:ask-for-info" and add "bug-cop:answered"
+/**
+ * Github Bugcop Bot
+ */
+// 1. bot matches label "bug-cop:ask-for-info", and if user have added context, remove "bug-cop:ask-for-info" and add "bug-cop:response-received"
+
 // for repo
 import { db } from "@/src/db";
 import { TaskMetaCollection } from "@/src/db/TaskMeta";
@@ -24,7 +28,7 @@ export const REPOLIST = [
   "https://github.com/Comfy-Org/desktop",
 ];
 export const ASKING_LABEL = "bug-cop:ask-for-info";
-export const ANSWERED_LABEL = "bug-cop:answered";
+// export const ANSWERED_LABEL = "bug-cop:answered"; // never managed by bot
 export const RESPONSE_RECEIVED_LABEL = "bug-cop:response-received";
 export const GithubBugcopTaskDefaultMeta = {
   repoUrls: REPOLIST,
@@ -230,14 +234,17 @@ async function processIssue(issue: GH["issue"]) {
 
   const responseReceived = hasNewComment || isBodyAddedContent; // check if user responsed info by new comment or body update
   const status: "responseReceived" | "askForInfo" = responseReceived ? "responseReceived" : "askForInfo";
-  const workinglabels = [ASKING_LABEL, ANSWERED_LABEL, RESPONSE_RECEIVED_LABEL];
+  const workinglabels = [ASKING_LABEL, RESPONSE_RECEIVED_LABEL];
   const labelSet = {
     responseReceived: [RESPONSE_RECEIVED_LABEL],
-    askForInfo: [ANSWERED_LABEL, ASKING_LABEL],
+    askForInfo: [ASKING_LABEL],
     closed: [], // clear bug-cop labels
   }[status];
 
-  const currentLabels = issue.labels.filter(l => l != null).map((l) => (typeof l === "string" ? l : (l.name ?? ""))).filter(Boolean);
+  const currentLabels = issue.labels
+    .filter((l) => l != null)
+    .map((l) => (typeof l === "string" ? l : (l.name ?? "")))
+    .filter(Boolean);
   const addLabels = difference(labelSet, currentLabels);
   const removeLabels = difference(
     currentLabels.filter((label) => workinglabels.includes(label)),


### PR DESCRIPTION
## Summary
- Comments out ANSWERED_LABEL export as it's never managed by the bot
- Removes ANSWERED_LABEL from working labels array and askForInfo label set
- Improves code formatting for current labels filtering

## Test plan
- [ ] Verify bug-cop bot continues to function correctly
- [ ] Confirm ANSWERED_LABEL is no longer automatically managed
- [ ] Test that askForInfo and responseReceived states work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)