### PR TITLE
feat: enhance Slack message handling for GitHub release notifications

### DIFF
--- a/app/tasks/gh-desktop-release-notification/findall.ts
+++ b/app/tasks/gh-desktop-release-notification/findall.ts
@@ -1,0 +1,5 @@
+import { GithubReleaseNotificationTask } from ".";
+
+if (import.meta.main) {
+  console.log(await GithubReleaseNotificationTask.find().toArray());
+}

--- a/app/tasks/gh-desktop-release-notification/index.ts
+++ b/app/tasks/gh-desktop-release-notification/index.ts
@@ -1,13 +1,12 @@
-import { db } from "@/src/db"
-import { gh } from "@/src/gh"
-import { parseUrlRepoOwner } from "@/src/parseOwnerRepo"
-import DIE from "@snomiao/die"
-import sflow from "sflow"
-import parseGithubUrl from "parse-github-url"
-import { slack } from "@/src/slack"
-import { getSlackChannel } from "@/src/slack/channels"
-import { slackMessageUrlParse, slackMessageUrlStringify } from "../gh-design/gh-design"
-import isCI from "is-ci"
+import { db } from "@/src/db";
+import { gh } from "@/src/gh";
+import { parseUrlRepoOwner } from "@/src/parseOwnerRepo";
+import { getSlackChannel } from "@/src/slack/channels";
+import DIE from "@snomiao/die";
+import isCI from "is-ci";
+import parseGithubUrl from "parse-github-url";
+import sflow from "sflow";
+import { upsertSlackMessage } from "./upsertSlackMessage";
 // workflow
 /**
  * 1. fetch repos latest releases
@@ -16,134 +15,102 @@ import isCI from "is-ci"
  * 4. if it's a pre-release, do nothing
  */
 const config = {
-    repos: [
-        'https://github.com/comfyanonymous/ComfyUI',
-        'https://github.com/Comfy-Org/desktop',
-    ],
-    slackChannel: 'desktop',
-    slackMessage: '🔮 {repo} <{url}|Release {version}> is stable! ',
-    sendSince: new Date('2025-08-02T00:00:00Z').toISOString(), // only send notifications for releases after this date (UTC)
-}
+  repos: ["https://github.com/comfyanonymous/ComfyUI", "https://github.com/Comfy-Org/desktop"],
+  slackChannel: "desktop",
+  slackMessage: "🔮 {repo} <{url}|Release {version}> is {status}!",
+  sendSince: new Date("2025-08-02T00:00:00Z").toISOString(), // only send notifications for releases after this date (UTC)
+};
 
 type GithubReleaseNotificationTask = {
-    url: string, // github release url
-    version?: string, // released version, e.g. v1.0.0, v2.0.0-beta.1
-    releasedAt?: Date,
-    isStable?: boolean, // true if the release is stable, false if it's a pre-release
-    slackMessage?: {
-        text: string
-        channel: string
-        url?: string // set after sent
-    }
-}
+  url: string; // github release url
+  version?: string; // released version, e.g. v1.0.0, v2.0.0-beta.1
+  createdAt: Date;
+  releasedAt?: Date;
+  isStable?: boolean; // true if the release is stable, false if it's a pre-release
+  status: "draft" | "prerelease" | "stable";
 
-const GithubReleaseNotificationTask = db.collection<GithubReleaseNotificationTask>('GithubReleaseNotificationTask')
-await GithubReleaseNotificationTask.createIndex({ url: 1 }, { unique: true })
-const save = async (task: GithubReleaseNotificationTask) => await GithubReleaseNotificationTask.findOneAndUpdate(
+  // drafted/pre-release message
+  slackMessage?: {
+    text: string;
+    channel: string;
+    url?: string; // set after sent
+  };
+};
+
+const GithubReleaseNotificationTask = db.collection<GithubReleaseNotificationTask>("GithubReleaseNotificationTask");
+await GithubReleaseNotificationTask.createIndex({ url: 1 }, { unique: true });
+const save = async (task: { url: string } & Partial<GithubReleaseNotificationTask>) =>
+  (await GithubReleaseNotificationTask.findOneAndUpdate(
     { url: task.url },
     { $set: task },
-    { upsert: true, returnDocument: 'after' }
-) || DIE('never')
+    { upsert: true, returnDocument: "after" },
+  )) || DIE("never");
 
 if (import.meta.main) {
-    await runGithubDesktopReleaseNotificationTask()
-    if (isCI) {
-        await db.close()
-        process.exit(0); // exit if running in CI
-    }
+  await runGithubDesktopReleaseNotificationTask();
+  if (isCI) {
+    await db.close();
+    process.exit(0); // exit if running in CI
+  }
 }
 
 async function runGithubDesktopReleaseNotificationTask() {
-    const pSlackChannelId = getSlackChannel(config.slackChannel).then(e => e.id || DIE(`unable to get slack channel ${config.slackChannel}`))
-    // patch
-    await GithubReleaseNotificationTask.deleteMany({
-        url: /https:\/\/comfy-organization\.slack\.com\/.*/,
-    })
-    await GithubReleaseNotificationTask.findOneAndUpdate({
-        version: "v0.4.60"
-    }, {
-        $set: {
-            // channel: "C07H3GLKDPF",
-            slackMessage: {
-                url: "https://comfy-organization.slack.com/archives/C07H3GLKDPF/p1754217152324349",
-                channel: await pSlackChannelId,
-                text: 'TODO',
-            }
-        }
-    })
+  const pSlackChannelId = getSlackChannel(config.slackChannel).then(
+    (e) => e.id || DIE(`unable to get slack channel ${config.slackChannel}`),
+  );
 
-    await sflow(config.repos)
-        .map(parseUrlRepoOwner)
-        .flatMap(({ owner, repo }) => gh.repos.listReleases({
-            owner,
-            repo,
-            per_page: 3,
-        }).then(e => e.data))
-        .map(async (release) => {
-            const url = release.html_url
-            // create task
-            let task = await save({
-                url,
-                isStable: !release.prerelease,
-                version: release.tag_name,
-                releasedAt: new Date(release.published_at || DIE('no published_at in release')),
-            })
-            if (!task.isStable) return task // not a stable release, skip
-            if (+task.releasedAt! < +new Date(config.sendSince)) return task // skip releases before the sendSince date
-
-            const draftSlackMessage = {
-                channel: config.slackChannel,
-                text: config.slackMessage
-                    .replace('{url}', task.url)
-                    .replace('{repo}', parseGithubUrl(task.url)?.repo || DIE(`unable parse REPO from URL ${task.url}`))
-                    .replace('{version}', task.version || DIE(`unable to parse version from task ${JSON.stringify(task)}`)),
-            }
-            console.log(task)
-            if (task.slackMessage?.url) {
-                // already notified, check if we need to update the text
-                if (task.slackMessage.text !== draftSlackMessage.text) {
-                    // update message content
-                    const ts = slackMessageUrlParse(task.slackMessage.url).ts
-                    console.log(draftSlackMessage)
-                    // console.log('slack.chat.update: ')
-                    const msg = await slack.chat.update({
-                        channel: task.slackMessage.channel,
-                        ts,
-                        text: draftSlackMessage.text,
-                    })
-                    // save updated message
-                    task = await save({
-                        url,
-                        slackMessage: {
-                            ...task.slackMessage!,
-                            url: slackMessageUrlStringify({ channel: task.slackMessage!.channel, ts: msg.ts || DIE('missing ts in edited slack message') }),
-                            text: draftSlackMessage.text!, // update text
-                        }
-                    }) // save the task with updated slack message
-                } else {
-                    // no need to update, pass
-                }
-            } else {
-                // not yet notified, send a new message
-                const channel = await pSlackChannelId
-                // notify the slack channel
-                const msg = await slack.chat.postMessage({
-                    text: draftSlackMessage.text,
-                    channel,
-                })
-                const slackUrl = slackMessageUrlStringify({ channel, ts: msg.ts! })
-                task = await save({
-                    url,
-                    slackMessage: {
-                        ...draftSlackMessage,
-                        url: slackUrl, // set the url after sent
-                    }
-                }) // save the task with slack message
-            }
-            return task
+  await sflow(config.repos)
+    .map(parseUrlRepoOwner)
+    .flatMap(({ owner, repo }) =>
+      gh.repos
+        .listReleases({
+          owner,
+          repo,
+          per_page: 3,
         })
-        .log()
-        .run()
+        .then((e) => e.data),
+    )
+    .map(async (release) => {
+      const url = release.html_url;
+      const status = release.draft ? "draft" : release.prerelease ? "prerelease" : "stable";
+
+      // create task
+      let task = await save({
+        url,
+        status: status,
+        isStable: status == "stable",
+        version: release.tag_name,
+        createdAt: new Date(release.created_at || DIE("no created_at in release, " + JSON.stringify(release))),
+        releasedAt: !release.published_at ? undefined : new Date(release.published_at),
+      });
+
+      if (+task.createdAt! < +new Date(config.sendSince)) return task; // skip releases before the sendSince date
+
+      const newSlackMessage = {
+        channel: await pSlackChannelId,
+        text: config.slackMessage
+          .replace("{url}", task.url)
+          .replace("{repo}", parseGithubUrl(task.url)?.repo || DIE(`unable parse REPO from URL ${task.url}`))
+          .replace("{version}", task.version || DIE(`unable to parse version from task ${JSON.stringify(task)}`))
+          .replace("{status}", task.status),
+      };
+
+      const anyExistedMsg = task.slackMessage;
+
+      // upsert message if new/changed
+      const shouldSendMessage = task.isStable || anyExistedMsg?.url;
+      if (shouldSendMessage && anyExistedMsg?.text?.trim() !== newSlackMessage.text.trim()) {
+        console.log(
+          anyExistedMsg?.text !== newSlackMessage.text,
+          JSON.stringify(anyExistedMsg?.text),
+          JSON.stringify(newSlackMessage.text),
+        );
+        task = await save({ url, slackMessage: await upsertSlackMessage(newSlackMessage) });
+      }
+      return task;
+    })
+    .log()
+    .run();
 }
 
 export default runGithubDesktopReleaseNotificationTask;

--- a/app/tasks/gh-desktop-release-notification/upsertSlackMessage.ts
+++ b/app/tasks/gh-desktop-release-notification/upsertSlackMessage.ts
@@ -1,0 +1,15 @@
+import { slack } from "@/src/slack";
+import { slackMessageUrlParse, slackMessageUrlStringify } from "../gh-design/gh-design";
+
+export async function upsertSlackMessage({ text, channel, url }: { text: string; channel: string; url?: string }) {
+  if (process.env.DRY_RUN) throw new Error("sending slack message: " + JSON.stringify({ text, channel, url }));
+  if (!url) {
+    const msg = await slack.chat.postMessage({ text, channel });
+    const url = slackMessageUrlStringify({ channel, ts: msg.ts! });
+    return { ...msg, url, text, channel };
+  }
+
+  const ts = slackMessageUrlParse(url).ts;
+  const msg = await slack.chat.update({ text, channel, ts });
+  return { ...msg, url, text, channel };
+}

--- a/app/tasks/gh-desktop-release-notification/upsertSlackMessage.ts
+++ b/app/tasks/gh-desktop-release-notification/upsertSlackMessage.ts
@@ -1,14 +1,24 @@
 import { slack } from "@/src/slack";
 import { slackMessageUrlParse, slackMessageUrlStringify } from "../gh-design/gh-design";
 
-export async function upsertSlackMessage({ text, channel, url }: { text: string; channel: string; url?: string }) {
+export async function upsertSlackMessage({
+  text,
+  channel,
+  url,
+  replyUrl,
+}: {
+  text: string;
+  channel: string;
+  url?: string;
+  replyUrl?: string;
+}) {
   if (process.env.DRY_RUN) throw new Error("sending slack message: " + JSON.stringify({ text, channel, url }));
   if (!url) {
-    const msg = await slack.chat.postMessage({ text, channel });
+    const thread_ts = !replyUrl ? undefined : slackMessageUrlParse(replyUrl).ts;
+    const msg = await slack.chat.postMessage({ text, channel, thread_ts });
     const url = slackMessageUrlStringify({ channel, ts: msg.ts! });
     return { ...msg, url, text, channel };
   }
-
   const ts = slackMessageUrlParse(url).ts;
   const msg = await slack.chat.update({ text, channel, ts });
   return { ...msg, url, text, channel };


### PR DESCRIPTION
## Summary
- Added status and upsert functionality to GitHub release notifications
- Created new upsertSlackMessage module for better code organization
- Updated slackMessage format to include release status for clearer notifications

## Changes
- Enhanced gh-desktop-release-notification with status handling
- Created upsertSlackMessage module for reusable Slack operations
- Improved release notification formatting

🤖 Generated with [Claude Code](https://claude.ai/code)