### PR TITLE
feat(coreping): filter out draft PRs from Core/Important PR notifications

### DIFF
--- a/app/tasks/coreping/index.tsx
+++ b/app/tasks/coreping/index.tsx
@@ -139,6 +139,7 @@ if (import.meta.main) {
 
           if (!corePrLabel) return saveTask({ url: html_url, status: "unrelated" });
           if (pr.state === "closed") return saveTask({ url: html_url, status: "closed" });
+          if (pr.draft) return saveTask({ url: html_url, status: "unrelated", statusMsg: "Draft PR, skipping" });
 
           // check timeline events
           const timeline = await fetchFullTimeline(html_url);


### PR DESCRIPTION
## Summary
- Filter out draft PRs from Core/Important PR notification messages
- Draft PRs are now marked as "unrelated" status and excluded from Slack reminders

## Problem
CorePing was including draft PRs in the Core/Important PR reminder messages sent to @comfyanonymous, but draft PRs are not ready for review yet and shouldn't be included in these notifications.

## Solution
Added a check for `pr.draft` after the existing checks for core labels and closed status. Draft PRs are now marked with status "unrelated" and a descriptive status message "Draft PR, skipping".

## Test plan
- [x] Verify the draft check is added in the correct location in the filtering logic
- [x] Confirm draft PRs will be excluded from both stale and fresh Core/Important PR collections
- [x] Ensure the change maintains existing functionality for non-draft PRs

🤖 Generated with [Claude Code](https://claude.ai/code)