### PR TITLE
feat: add ComfyUI_frontend release notification task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,4 +114,4 @@ SFlow is a powerful functional stream processing library used throughout the cod
 - **Package**: `sflow@1.24.0` 
 - **Author**: snomiao
 - **License**: MIT
-- **Core Conce
+- **Core Concepts**: SFlow is built around composable stream operators, lazy evaluation, and support for both synchronous and asynchronous data flows.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,3 +102,16 @@ const stats = await getGhCacheStats();
 
 - Short args: `gh.repos.get({"owner":"octocat","repo":"Hello-World"})#b3117af2`
 - Long args: `gh.repos.get({"owner":"octocat","descripti...bbbbbbbbbb"})#4240f076`
+
+## SFlow Stream Processing Library
+
+### Overview
+
+SFlow is a powerful functional stream processing library used throughout the codebase for handling asynchronous data operations. It provides a rich set of utilities for transforming streams with a functional programming approach, similar to RxJS but optimized for modern JavaScript/TypeScript and WebStreams.
+
+### Implementation Details
+
+- **Package**: `sflow@1.24.0` 
+- **Author**: snomiao
+- **License**: MIT
+- **Core Conce

--- a/app/tasks/gh-frontend-release-notification/index.spec.ts
+++ b/app/tasks/gh-frontend-release-notification/index.spec.ts
@@ -1,11 +1,9 @@
-import { describe, expect, it, jest, beforeEach, afterEach } from "@jest/globals";
 import { db } from "@/src/db";
 import { gh } from "@/src/gh";
 import { parseGithubRepoUrl } from "@/src/parseOwnerRepo";
 import { getSlackChannel } from "@/src/slack/channels";
-import runGithubFrontendReleaseNotificationTask, {
-  GithubFrontendReleaseNotificationTask,
-} from "./index";
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import runGithubFrontendReleaseNotificationTask from "./index";
 
 jest.mock("@/src/gh");
 jest.mock("@/src/slack/channels");
@@ -13,25 +11,32 @@ jest.mock("../gh-desktop-release-notification/upsertSlackMessage");
 
 const mockGh = gh as jest.Mocked<typeof gh>;
 const mockGetSlackChannel = getSlackChannel as jest.MockedFunction<typeof getSlackChannel>;
+const { upsertSlackMessage } = jest.requireMock("../gh-desktop-release-notification/upsertSlackMessage");
 
 describe("GithubFrontendReleaseNotificationTask", () => {
   let collection: any;
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    
+
     collection = {
       findOne: jest.fn(),
       findOneAndUpdate: jest.fn(),
       createIndex: jest.fn(),
     };
-    
-    jest.spyOn(db, 'collection').mockReturnValue(collection);
-    
+
+    jest.spyOn(db, "collection").mockReturnValue(collection);
+
     mockGetSlackChannel.mockResolvedValue({
       id: "test-channel-id",
       name: "frontend",
     } as any);
+
+    upsertSlackMessage.mockResolvedValue({
+      text: "mocked message",
+      channel: "test-channel-id",
+      url: "https://slack.com/message/123",
+    });
   });
 
   afterEach(async () => {
@@ -49,7 +54,7 @@ describe("GithubFrontendReleaseNotificationTask", () => {
   });
 
   describe("Release Processing", () => {
-    it("should process stable releases", async () => {
+    it("should process stable releases and send message only on first occurrence", async () => {
       const mockRelease = {
         html_url: "https://github.com/Comfy-Org/ComfyUI_frontend/releases/tag/v1.0.0",
         tag_name: "v1.0.0",
@@ -66,13 +71,29 @@ describe("GithubFrontendReleaseNotificationTask", () => {
         }),
       } as any;
 
-      collection.findOneAndUpdate.mockResolvedValue({
+      // First call - no existing message
+      collection.findOneAndUpdate.mockResolvedValueOnce({
         url: mockRelease.html_url,
         version: mockRelease.tag_name,
         status: "stable",
         isStable: true,
         createdAt: new Date(mockRelease.created_at),
         releasedAt: new Date(mockRelease.published_at),
+      });
+
+      // Second call - save with message
+      collection.findOneAndUpdate.mockResolvedValueOnce({
+        url: mockRelease.html_url,
+        version: mockRelease.tag_name,
+        status: "stable",
+        isStable: true,
+        createdAt: new Date(mockRelease.created_at),
+        releasedAt: new Date(mockRelease.published_at),
+        slackMessage: {
+          text: "🎨 ComfyUI_frontend <https://github.com/Comfy-Org/ComfyUI_frontend/releases/tag/v1.0.0|Release v1.0.0> is stable!",
+          channel: "test-channel-id",
+          url: "https://slack.com/message/123",
+        },
       });
 
       await runGithubFrontendReleaseNotificationTask();
@@ -83,21 +104,53 @@ describe("GithubFrontendReleaseNotificationTask", () => {
         per_page: 3,
       });
 
-      expect(collection.findOneAndUpdate).toHaveBeenCalledWith(
-        { url: mockRelease.html_url },
+      expect(upsertSlackMessage).toHaveBeenCalledWith(
         expect.objectContaining({
-          $set: expect.objectContaining({
-            url: mockRelease.html_url,
-            version: mockRelease.tag_name,
-            status: "stable",
-            isStable: true,
-          }),
+          channel: "test-channel-id",
+          text: expect.stringContaining("stable"),
         }),
-        { upsert: true, returnDocument: "after" }
       );
     });
 
-    it("should process prerelease", async () => {
+    it("should not send duplicate messages for unchanged releases", async () => {
+      const mockRelease = {
+        html_url: "https://github.com/Comfy-Org/ComfyUI_frontend/releases/tag/v1.0.0",
+        tag_name: "v1.0.0",
+        draft: false,
+        prerelease: false,
+        created_at: new Date().toISOString(),
+        published_at: new Date().toISOString(),
+        body: "Release notes",
+      };
+
+      mockGh.repos = {
+        listReleases: jest.fn().mockResolvedValue({
+          data: [mockRelease],
+        }),
+      } as any;
+
+      // Return task with existing message text matching new message
+      collection.findOneAndUpdate.mockResolvedValue({
+        url: mockRelease.html_url,
+        version: mockRelease.tag_name,
+        status: "stable",
+        isStable: true,
+        createdAt: new Date(mockRelease.created_at),
+        releasedAt: new Date(mockRelease.published_at),
+        slackMessage: {
+          text: "🎨 ComfyUI_frontend <https://github.com/Comfy-Org/ComfyUI_frontend/releases/tag/v1.0.0|Release v1.0.0> is stable!",
+          channel: "test-channel-id",
+          url: "https://slack.com/message/123",
+        },
+      });
+
+      await runGithubFrontendReleaseNotificationTask();
+
+      // Should not call upsertSlackMessage since text hasn't changed
+      expect(upsertSlackMessage).not.toHaveBeenCalled();
+    });
+
+    it("should process prerelease and send drafting message", async () => {
       const mockPrerelease = {
         html_url: "https://github.com/Comfy-Org/ComfyUI_frontend/releases/tag/v1.0.0-beta.1",
         tag_name: "v1.0.0-beta.1",
@@ -114,7 +167,8 @@ describe("GithubFrontendReleaseNotificationTask", () => {
         }),
       } as any;
 
-      collection.findOneAndUpdate.mockResolvedValue({
+      // First call - save initial data
+      collection.findOneAndUpdate.mockResolvedValueOnce({
         url: mockPrerelease.html_url,
         version: mockPrerelease.tag_name,
         status: "prerelease",
@@ -123,17 +177,28 @@ describe("GithubFrontendReleaseNotificationTask", () => {
         releasedAt: new Date(mockPrerelease.published_at),
       });
 
+      // Second call - save with drafting message
+      collection.findOneAndUpdate.mockResolvedValueOnce({
+        url: mockPrerelease.html_url,
+        version: mockPrerelease.tag_name,
+        status: "prerelease",
+        isStable: false,
+        createdAt: new Date(mockPrerelease.created_at),
+        releasedAt: new Date(mockPrerelease.published_at),
+        slackMessageDrafting: {
+          text: "🎨 ComfyUI_frontend <https://github.com/Comfy-Org/ComfyUI_frontend/releases/tag/v1.0.0-beta.1|Release v1.0.0-beta.1> is prerelease!",
+          channel: "test-channel-id",
+          url: "https://slack.com/message/456",
+        },
+      });
+
       await runGithubFrontendReleaseNotificationTask();
 
-      expect(collection.findOneAndUpdate).toHaveBeenCalledWith(
-        { url: mockPrerelease.html_url },
+      expect(upsertSlackMessage).toHaveBeenCalledWith(
         expect.objectContaining({
-          $set: expect.objectContaining({
-            status: "prerelease",
-            isStable: false,
-          }),
+          channel: "test-channel-id",
+          text: expect.stringContaining("prerelease"),
         }),
-        { upsert: true, returnDocument: "after" }
       );
     });
 
@@ -174,7 +239,7 @@ describe("GithubFrontendReleaseNotificationTask", () => {
             releasedAt: undefined,
           }),
         }),
-        { upsert: true, returnDocument: "after" }
+        { upsert: true, returnDocument: "after" },
       );
     });
 
@@ -206,7 +271,65 @@ describe("GithubFrontendReleaseNotificationTask", () => {
 
       await runGithubFrontendReleaseNotificationTask();
 
+      // Should save the release but not send a message
       expect(collection.findOneAndUpdate).toHaveBeenCalledTimes(1);
+      expect(upsertSlackMessage).not.toHaveBeenCalled();
+    });
+
+    it("should update message when release text changes", async () => {
+      const mockRelease = {
+        html_url: "https://github.com/Comfy-Org/ComfyUI_frontend/releases/tag/v1.0.0",
+        tag_name: "v1.0.1", // Changed version
+        draft: false,
+        prerelease: false,
+        created_at: new Date().toISOString(),
+        published_at: new Date().toISOString(),
+        body: "Updated release notes",
+      };
+
+      mockGh.repos = {
+        listReleases: jest.fn().mockResolvedValue({
+          data: [mockRelease],
+        }),
+      } as any;
+
+      // Return task with old message text
+      collection.findOneAndUpdate.mockResolvedValueOnce({
+        url: mockRelease.html_url,
+        version: mockRelease.tag_name,
+        status: "stable",
+        isStable: true,
+        createdAt: new Date(mockRelease.created_at),
+        releasedAt: new Date(mockRelease.published_at),
+        slackMessage: {
+          text: "🎨 ComfyUI_frontend <https://github.com/Comfy-Org/ComfyUI_frontend/releases/tag/v1.0.0|Release v1.0.0> is stable!",
+          channel: "test-channel-id",
+          url: "https://slack.com/message/123",
+        },
+      });
+
+      // Second call after update
+      collection.findOneAndUpdate.mockResolvedValueOnce({
+        url: mockRelease.html_url,
+        version: mockRelease.tag_name,
+        status: "stable",
+        isStable: true,
+        slackMessage: {
+          text: "🎨 ComfyUI_frontend <https://github.com/Comfy-Org/ComfyUI_frontend/releases/tag/v1.0.0|Release v1.0.1> is stable!",
+          channel: "test-channel-id",
+          url: "https://slack.com/message/123",
+        },
+      });
+
+      await runGithubFrontendReleaseNotificationTask();
+
+      // Should update the message since text changed
+      expect(upsertSlackMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://slack.com/message/123",
+          text: expect.stringContaining("v1.0.1"),
+        }),
+      );
     });
   });
 

--- a/app/tasks/gh-frontend-release-notification/index.spec.ts
+++ b/app/tasks/gh-frontend-release-notification/index.spec.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, jest, beforeEach, afterEach } from "@jest/globals";
+import { db } from "@/src/db";
+import { gh } from "@/src/gh";
+import { parseGithubRepoUrl } from "@/src/parseOwnerRepo";
+import { getSlackChannel } from "@/src/slack/channels";
+import runGithubFrontendReleaseNotificationTask, {
+  GithubFrontendReleaseNotificationTask,
+} from "./index";
+
+jest.mock("@/src/gh");
+jest.mock("@/src/slack/channels");
+jest.mock("../gh-desktop-release-notification/upsertSlackMessage");
+
+const mockGh = gh as jest.Mocked<typeof gh>;
+const mockGetSlackChannel = getSlackChannel as jest.MockedFunction<typeof getSlackChannel>;
+
+describe("GithubFrontendReleaseNotificationTask", () => {
+  let collection: any;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    
+    collection = {
+      findOne: jest.fn(),
+      findOneAndUpdate: jest.fn(),
+      createIndex: jest.fn(),
+    };
+    
+    jest.spyOn(db, 'collection').mockReturnValue(collection);
+    
+    mockGetSlackChannel.mockResolvedValue({
+      id: "test-channel-id",
+      name: "frontend",
+    } as any);
+  });
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+  });
+
+  describe("parseGithubRepoUrl", () => {
+    it("should correctly parse ComfyUI_frontend repo URL", () => {
+      const result = parseGithubRepoUrl("https://github.com/Comfy-Org/ComfyUI_frontend");
+      expect(result).toEqual({
+        owner: "Comfy-Org",
+        repo: "ComfyUI_frontend",
+      });
+    });
+  });
+
+  describe("Release Processing", () => {
+    it("should process stable releases", async () => {
+      const mockRelease = {
+        html_url: "https://github.com/Comfy-Org/ComfyUI_frontend/releases/tag/v1.0.0",
+        tag_name: "v1.0.0",
+        draft: false,
+        prerelease: false,
+        created_at: new Date().toISOString(),
+        published_at: new Date().toISOString(),
+        body: "Release notes",
+      };
+
+      mockGh.repos = {
+        listReleases: jest.fn().mockResolvedValue({
+          data: [mockRelease],
+        }),
+      } as any;
+
+      collection.findOneAndUpdate.mockResolvedValue({
+        url: mockRelease.html_url,
+        version: mockRelease.tag_name,
+        status: "stable",
+        isStable: true,
+        createdAt: new Date(mockRelease.created_at),
+        releasedAt: new Date(mockRelease.published_at),
+      });
+
+      await runGithubFrontendReleaseNotificationTask();
+
+      expect(mockGh.repos.listReleases).toHaveBeenCalledWith({
+        owner: "Comfy-Org",
+        repo: "ComfyUI_frontend",
+        per_page: 3,
+      });
+
+      expect(collection.findOneAndUpdate).toHaveBeenCalledWith(
+        { url: mockRelease.html_url },
+        expect.objectContaining({
+          $set: expect.objectContaining({
+            url: mockRelease.html_url,
+            version: mockRelease.tag_name,
+            status: "stable",
+            isStable: true,
+          }),
+        }),
+        { upsert: true, returnDocument: "after" }
+      );
+    });
+
+    it("should process prerelease", async () => {
+      const mockPrerelease = {
+        html_url: "https://github.com/Comfy-Org/ComfyUI_frontend/releases/tag/v1.0.0-beta.1",
+        tag_name: "v1.0.0-beta.1",
+        draft: false,
+        prerelease: true,
+        created_at: new Date().toISOString(),
+        published_at: new Date().toISOString(),
+        body: "Beta release notes",
+      };
+
+      mockGh.repos = {
+        listReleases: jest.fn().mockResolvedValue({
+          data: [mockPrerelease],
+        }),
+      } as any;
+
+      collection.findOneAndUpdate.mockResolvedValue({
+        url: mockPrerelease.html_url,
+        version: mockPrerelease.tag_name,
+        status: "prerelease",
+        isStable: false,
+        createdAt: new Date(mockPrerelease.created_at),
+        releasedAt: new Date(mockPrerelease.published_at),
+      });
+
+      await runGithubFrontendReleaseNotificationTask();
+
+      expect(collection.findOneAndUpdate).toHaveBeenCalledWith(
+        { url: mockPrerelease.html_url },
+        expect.objectContaining({
+          $set: expect.objectContaining({
+            status: "prerelease",
+            isStable: false,
+          }),
+        }),
+        { upsert: true, returnDocument: "after" }
+      );
+    });
+
+    it("should process draft releases", async () => {
+      const mockDraft = {
+        html_url: "https://github.com/Comfy-Org/ComfyUI_frontend/releases/tag/v2.0.0",
+        tag_name: "v2.0.0",
+        draft: true,
+        prerelease: false,
+        created_at: new Date().toISOString(),
+        published_at: null,
+        body: "Draft release notes",
+      };
+
+      mockGh.repos = {
+        listReleases: jest.fn().mockResolvedValue({
+          data: [mockDraft],
+        }),
+      } as any;
+
+      collection.findOneAndUpdate.mockResolvedValue({
+        url: mockDraft.html_url,
+        version: mockDraft.tag_name,
+        status: "draft",
+        isStable: false,
+        createdAt: new Date(mockDraft.created_at),
+        releasedAt: undefined,
+      });
+
+      await runGithubFrontendReleaseNotificationTask();
+
+      expect(collection.findOneAndUpdate).toHaveBeenCalledWith(
+        { url: mockDraft.html_url },
+        expect.objectContaining({
+          $set: expect.objectContaining({
+            status: "draft",
+            isStable: false,
+            releasedAt: undefined,
+          }),
+        }),
+        { upsert: true, returnDocument: "after" }
+      );
+    });
+
+    it("should skip old releases before sendSince date", async () => {
+      const oldRelease = {
+        html_url: "https://github.com/Comfy-Org/ComfyUI_frontend/releases/tag/v0.1.0",
+        tag_name: "v0.1.0",
+        draft: false,
+        prerelease: false,
+        created_at: "2024-01-01T00:00:00Z",
+        published_at: "2024-01-01T00:00:00Z",
+        body: "Old release",
+      };
+
+      mockGh.repos = {
+        listReleases: jest.fn().mockResolvedValue({
+          data: [oldRelease],
+        }),
+      } as any;
+
+      collection.findOneAndUpdate.mockResolvedValue({
+        url: oldRelease.html_url,
+        version: oldRelease.tag_name,
+        status: "stable",
+        isStable: true,
+        createdAt: new Date(oldRelease.created_at),
+        releasedAt: new Date(oldRelease.published_at),
+      });
+
+      await runGithubFrontendReleaseNotificationTask();
+
+      expect(collection.findOneAndUpdate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Database Index", () => {
+    it("should create unique index on url field", async () => {
+      expect(collection.createIndex).toHaveBeenCalledWith({ url: 1 }, { unique: true });
+    });
+  });
+});

--- a/app/tasks/gh-frontend-release-notification/index.ts
+++ b/app/tasks/gh-frontend-release-notification/index.ts
@@ -1,0 +1,135 @@
+import { db } from "@/src/db";
+import { gh } from "@/src/gh";
+import { parseGithubRepoUrl } from "@/src/parseOwnerRepo";
+import { getSlackChannel } from "@/src/slack/channels";
+import DIE from "@snomiao/die";
+import isCI from "is-ci";
+import parseGithubUrl from "parse-github-url";
+import sflow from "sflow";
+import { upsertSlackMessage } from "../gh-desktop-release-notification/upsertSlackMessage";
+
+/**
+ * GitHub Frontend Release Notification Task
+ * 
+ * Workflow:
+ * 1. Fetch ComfyUI_frontend repo latest releases
+ * 2. Save the release info to the database
+ * 3. If it's stable, notify the release to slack
+ * 4. If it's a pre-release, send drafting notification
+ */
+
+const config = {
+  repos: ["https://github.com/Comfy-Org/ComfyUI_frontend"],
+  slackChannel: "frontend",
+  slackMessage: "🎨 {repo} <{url}|Release {version}> is {status}!",
+  sendSince: new Date("2025-08-02T00:00:00Z").toISOString(),
+};
+
+export type GithubFrontendReleaseNotificationTask = {
+  url: string;
+  version?: string;
+  createdAt: Date;
+  releasedAt?: Date;
+  isStable?: boolean;
+  status: "draft" | "prerelease" | "stable";
+  
+  slackMessageDrafting?: {
+    text: string;
+    channel: string;
+    url?: string;
+  };
+  
+  slackMessage?: {
+    text: string;
+    channel: string;
+    url?: string;
+  };
+};
+
+export const GithubFrontendReleaseNotificationTask = db.collection<GithubFrontendReleaseNotificationTask>(
+  "GithubFrontendReleaseNotificationTask",
+);
+
+await GithubFrontendReleaseNotificationTask.createIndex({ url: 1 }, { unique: true });
+
+const save = async (task: { url: string } & Partial<GithubFrontendReleaseNotificationTask>) =>
+  (await GithubFrontendReleaseNotificationTask.findOneAndUpdate(
+    { url: task.url },
+    { $set: task },
+    { upsert: true, returnDocument: "after" },
+  )) || DIE("never");
+
+if (import.meta.main) {
+  await runGithubFrontendReleaseNotificationTask();
+  if (isCI) {
+    await db.close();
+    process.exit(0);
+  }
+}
+
+async function runGithubFrontendReleaseNotificationTask() {
+  const pSlackChannelId = getSlackChannel(config.slackChannel).then(
+    (e) => e.id || DIE(`unable to get slack channel ${config.slackChannel}`),
+  );
+
+  await sflow(config.repos)
+    .map(parseGithubRepoUrl)
+    .flatMap(({ owner, repo }) =>
+      gh.repos
+        .listReleases({
+          owner,
+          repo,
+          per_page: 3,
+        })
+        .then((e) => e.data),
+    )
+    .map(async (release) => {
+      const url = release.html_url;
+      const status = release.draft ? "draft" : release.prerelease ? "prerelease" : "stable";
+
+      let task = await save({
+        url,
+        status: status,
+        isStable: status == "stable",
+        version: release.tag_name,
+        createdAt: new Date(release.created_at || DIE("no created_at in release, " + JSON.stringify(release))),
+        releasedAt: !release.published_at ? undefined : new Date(release.published_at),
+      });
+
+      if (+task.createdAt! < +new Date(config.sendSince)) return task;
+
+      const newSlackMessage = {
+        channel: await pSlackChannelId,
+        text: config.slackMessage
+          .replace("{url}", task.url)
+          .replace("{repo}", parseGithubUrl(task.url)?.repo || DIE(`unable parse REPO from URL ${task.url}`))
+          .replace("{version}", task.version || DIE(`unable to parse version from task ${JSON.stringify(task)}`))
+          .replace("{status}", task.status),
+      };
+
+      const shouldSendDraftingMessage = !task.isStable && !task.slackMessageDrafting?.url;
+      if (shouldSendDraftingMessage && task.slackMessageDrafting?.text?.trim() !== newSlackMessage.text.trim()) {
+        task = await save({
+          url,
+          slackMessageDrafting: await upsertSlackMessage(newSlackMessage),
+        });
+      }
+
+      const shouldSendMessage = task.isStable && !task.slackMessage?.url;
+      if (shouldSendMessage && task.slackMessage?.text?.trim() !== newSlackMessage.text.trim()) {
+        task = await save({
+          url,
+          slackMessage: await upsertSlackMessage({
+            ...newSlackMessage,
+            replyUrl: task.slackMessageDrafting?.url,
+          }),
+        });
+      }
+      
+      return task;
+    })
+    .log()
+    .run();
+}
+
+export default runGithubFrontendReleaseNotificationTask;

--- a/app/tasks/run-gh-tasks.ts
+++ b/app/tasks/run-gh-tasks.ts
@@ -7,6 +7,7 @@ import runGithubBugcopTask from "../../run/gh-bugcop/gh-bugcop";
 import runGithubBountyTask from "./gh-bounty/gh-bounty";
 import { runGithubDesignTask } from "./gh-design/gh-design";
 import runGithubDesktopReleaseNotificationTask from "./gh-desktop-release-notification/index";
+import runGithubFrontendReleaseNotificationTask from "./gh-frontend-release-notification/index";
 
 const TASKS = [
   {
@@ -20,6 +21,10 @@ const TASKS = [
   {
     name: "GitHub Desktop Release Notification Task",
     run: runGithubDesktopReleaseNotificationTask,
+  },
+  {
+    name: "GitHub Frontend Release Notification Task",
+    run: runGithubFrontendReleaseNotificationTask,
   },
   {
     name: "GitHub Bugcop Task",


### PR DESCRIPTION
## Summary
- Created a new GitHub release notification task for monitoring the ComfyUI_frontend repository
- Based on the existing desktop release notification pattern
- Sends notifications to the #frontend Slack channel

## Changes
- Added `app/tasks/gh-frontend-release-notification/index.ts` - main task implementation
- Added `app/tasks/gh-frontend-release-notification/index.spec.ts` - comprehensive test coverage
- Updated `app/tasks/run-gh-tasks.ts` to include the new frontend release notification task
- Updated CLAUDE.md with development notes

## Features
- Monitors the ComfyUI_frontend repository for new releases
- Distinguishes between stable, prerelease, and draft releases
- Sends appropriate Slack notifications for each release type
- Stores release information in MongoDB for tracking
- Filters out old releases before configured date (2025-08-02)

## Test plan
- [x] Created comprehensive unit tests with mocked dependencies
- [ ] Manual testing with dry run mode
- [ ] Integration testing with actual GitHub API and Slack

🤖 Generated with [Claude Code](https://claude.ai/code)