### PR TITLE
chore: adjust EasyLabel workflow timeout and schedule

### DIFF
--- a/.github/workflows/easylabel.yaml
+++ b/.github/workflows/easylabel.yaml
@@ -3,7 +3,7 @@ name: "EasyLabel - Automated PR Labeling"
 on:
   workflow_dispatch:
   schedule:
-    # Run every 2 hour
+    # Run every 2 hours
     - cron: "0 */2 * * *"
   push:
     branches:

--- a/.github/workflows/easylabel.yaml
+++ b/.github/workflows/easylabel.yaml
@@ -3,7 +3,8 @@ name: "EasyLabel - Automated PR Labeling"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 * * * *" # Run every hour at minute 0
+    # Run every 2 hour
+    - cron: "0 */2 * * *"
   push:
     branches:
       - easylabel-debug
@@ -11,7 +12,7 @@ on:
 jobs:
   run_easylabel:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary
• Increase workflow timeout from 10 to 30 minutes to prevent premature timeouts
• Change schedule from hourly to every 2 hours to reduce frequency

## Test plan
- [x] Verify workflow syntax is valid
- [ ] Monitor workflow execution after merge to ensure it runs as expected

🤖 Generated with [Claude Code](https://claude.ai/code)