### PR TITLE
Notify desktop channel when core stable release is tagged

### DIFF
--- a/.github/workflows/gh-combined-tasks.yaml
+++ b/.github/workflows/gh-combined-tasks.yaml
@@ -17,6 +17,7 @@ on:
       - "app/tasks/gh-bounty/**"
       - "app/tasks/gh-design/**"
       - "app/tasks/gh-desktop-release-notification/**"
+      - "app/tasks/gh-core-tag-notification/**"
       - "app/tasks/gh-bugcop/**"
 
 jobs:

--- a/app/tasks/gh-core-tag-notification/index.spec.ts
+++ b/app/tasks/gh-core-tag-notification/index.spec.ts
@@ -1,14 +1,25 @@
-import { describe, expect, it, jest, beforeEach, afterEach } from "bun:test";
 import { gh } from "@/src/gh";
-import { db } from "@/src/db";
 import { getSlackChannel } from "@/src/slack/channels";
+import { afterEach, beforeEach, describe, expect, it, jest } from "bun:test";
 import { upsertSlackMessage } from "../gh-desktop-release-notification/upsertSlackMessage";
-import runGithubCoreTagNotificationTask, { GithubCoreTagNotificationTask } from "./index";
 
 jest.mock("@/src/gh");
-jest.mock("@/src/db");
 jest.mock("@/src/slack/channels");
 jest.mock("../gh-desktop-release-notification/upsertSlackMessage");
+
+const mockCollection = {
+  createIndex: jest.fn().mockResolvedValue({}),
+  findOne: jest.fn().mockResolvedValue(null),
+  findOneAndUpdate: jest.fn().mockImplementation((_filter, update) => Promise.resolve(update.$set)),
+};
+
+jest.mock("@/src/db", () => ({
+  db: {
+    collection: jest.fn(() => mockCollection),
+  },
+}));
+
+import runGithubCoreTagNotificationTask from "./index";
 
 describe("GithubCoreTagNotificationTask", () => {
   const mockGh = gh as jest.Mocked<typeof gh>;
@@ -17,17 +28,8 @@ describe("GithubCoreTagNotificationTask", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-
-    const mockCollection = {
-      createIndex: jest.fn().mockResolvedValue({}),
-      findOne: jest.fn().mockResolvedValue(null),
-      findOneAndUpdate: jest.fn().mockImplementation((_filter, update) =>
-        Promise.resolve(update.$set)
-      ),
-    };
-
-    (GithubCoreTagNotificationTask as any) = mockCollection;
-
+    mockCollection.findOne.mockResolvedValue(null);
+    mockCollection.findOneAndUpdate.mockImplementation((_filter, update) => Promise.resolve(update.$set));
     mockGetSlackChannel.mockResolvedValue({ id: "test-channel-id", name: "desktop" } as any);
   });
 
@@ -41,12 +43,12 @@ describe("GithubCoreTagNotificationTask", () => {
         name: "v0.2.1",
         commit: {
           sha: "abc123def456",
-          url: "https://api.github.com/repos/comfyanonymous/ComfyUI/commits/abc123def456"
+          url: "https://api.github.com/repos/comfyanonymous/ComfyUI/commits/abc123def456",
         },
         zipball_url: "https://api.github.com/repos/comfyanonymous/ComfyUI/zipball/v0.2.1",
         tarball_url: "https://api.github.com/repos/comfyanonymous/ComfyUI/tarball/v0.2.1",
-        node_id: "REF_kwDOI_"
-      }
+        node_id: "REF_kwDOI_",
+      },
     ];
 
     mockGh.repos = {
@@ -55,20 +57,20 @@ describe("GithubCoreTagNotificationTask", () => {
         data: {
           commit: {
             author: { date: new Date().toISOString() },
-            committer: { date: new Date().toISOString() }
-          }
-        }
-      })
+            committer: { date: new Date().toISOString() },
+          },
+        },
+      }),
     } as any;
 
     mockGh.git = {
-      getTag: jest.fn().mockRejectedValue(new Error("Not an annotated tag"))
+      getTag: jest.fn().mockRejectedValue(new Error("Not an annotated tag")),
     } as any;
 
     mockUpsertSlackMessage.mockResolvedValue({
       text: "Test message",
       channel: "test-channel-id",
-      url: "https://slack.com/message/123"
+      url: "https://slack.com/message/123",
     });
 
     await runGithubCoreTagNotificationTask();
@@ -86,9 +88,9 @@ describe("GithubCoreTagNotificationTask", () => {
         name: "v0.2.2",
         commit: {
           sha: "def789ghi012",
-          url: "https://api.github.com/repos/comfyanonymous/ComfyUI/commits/def789ghi012"
-        }
-      }
+          url: "https://api.github.com/repos/comfyanonymous/ComfyUI/commits/def789ghi012",
+        },
+      },
     ];
 
     mockGh.repos = {
@@ -96,10 +98,10 @@ describe("GithubCoreTagNotificationTask", () => {
       getCommit: jest.fn().mockResolvedValue({
         data: {
           commit: {
-            author: { date: new Date().toISOString() }
-          }
-        }
-      })
+            author: { date: new Date().toISOString() },
+          },
+        },
+      }),
     } as any;
 
     mockGh.git = {
@@ -109,22 +111,22 @@ describe("GithubCoreTagNotificationTask", () => {
           tagger: {
             date: new Date().toISOString(),
             name: "Test Author",
-            email: "test@example.com"
+            email: "test@example.com",
           },
-          message: "Release v0.2.2 with new features"
-        }
-      })
+          message: "Release v0.2.2 with new features",
+        },
+      }),
     } as any;
 
     mockUpsertSlackMessage.mockResolvedValue({
       text: "Test message",
       channel: "test-channel-id",
-      url: "https://slack.com/message/456"
+      url: "https://slack.com/message/456",
     });
 
     await runGithubCoreTagNotificationTask();
 
-    expect((GithubCoreTagNotificationTask as any).findOneAndUpdate).toHaveBeenCalled();
+    expect(mockCollection.findOneAndUpdate).toHaveBeenCalled();
   });
 
   it("should send Slack notifications for new tags", async () => {
@@ -133,9 +135,9 @@ describe("GithubCoreTagNotificationTask", () => {
         name: "v0.2.3",
         commit: {
           sha: "123abc456def",
-          url: "https://api.github.com/repos/comfyanonymous/ComfyUI/commits/123abc456def"
-        }
-      }
+          url: "https://api.github.com/repos/comfyanonymous/ComfyUI/commits/123abc456def",
+        },
+      },
     ];
 
     mockGh.repos = {
@@ -143,28 +145,30 @@ describe("GithubCoreTagNotificationTask", () => {
       getCommit: jest.fn().mockResolvedValue({
         data: {
           commit: {
-            author: { date: new Date().toISOString() }
-          }
-        }
-      })
+            author: { date: new Date().toISOString() },
+          },
+        },
+      }),
     } as any;
 
     mockGh.git = {
-      getTag: jest.fn().mockRejectedValue(new Error("Not an annotated tag"))
+      getTag: jest.fn().mockRejectedValue(new Error("Not an annotated tag")),
     } as any;
 
     mockUpsertSlackMessage.mockResolvedValue({
       text: "🏷️ ComfyUI <https://github.com/comfyanonymous/ComfyUI/releases/tag/v0.2.3|Tag v0.2.3> created!",
       channel: "test-channel-id",
-      url: "https://slack.com/message/789"
+      url: "https://slack.com/message/789",
     });
 
     await runGithubCoreTagNotificationTask();
 
-    expect(mockUpsertSlackMessage).toHaveBeenCalledWith(expect.objectContaining({
-      channel: "test-channel-id",
-      text: expect.stringContaining("v0.2.3"),
-    }));
+    expect(mockUpsertSlackMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "test-channel-id",
+        text: expect.stringContaining("v0.2.3"),
+      }),
+    );
   });
 
   it("should not send duplicate notifications for existing tags", async () => {
@@ -173,24 +177,24 @@ describe("GithubCoreTagNotificationTask", () => {
         name: "v0.2.0",
         commit: {
           sha: "existing123",
-          url: "https://api.github.com/repos/comfyanonymous/ComfyUI/commits/existing123"
-        }
-      }
+          url: "https://api.github.com/repos/comfyanonymous/ComfyUI/commits/existing123",
+        },
+      },
     ];
 
     mockGh.repos = {
       listTags: jest.fn().mockResolvedValue({ data: mockTags }),
     } as any;
 
-    (GithubCoreTagNotificationTask as any).findOne.mockResolvedValue({
+    mockCollection.findOne.mockResolvedValue({
       tagName: "v0.2.0",
       commitSha: "existing123",
       url: "https://github.com/comfyanonymous/ComfyUI/releases/tag/v0.2.0",
       slackMessage: {
         text: "Already sent",
         channel: "test-channel-id",
-        url: "https://slack.com/message/old"
-      }
+        url: "https://slack.com/message/old",
+      },
     });
 
     await runGithubCoreTagNotificationTask();
@@ -204,9 +208,9 @@ describe("GithubCoreTagNotificationTask", () => {
         name: "v0.3.0",
         commit: {
           sha: "annotated123",
-          url: "https://api.github.com/repos/comfyanonymous/ComfyUI/commits/annotated123"
-        }
-      }
+          url: "https://api.github.com/repos/comfyanonymous/ComfyUI/commits/annotated123",
+        },
+      },
     ];
 
     const tagMessage = "Major release with breaking changes";
@@ -222,24 +226,26 @@ describe("GithubCoreTagNotificationTask", () => {
           tagger: {
             date: new Date().toISOString(),
             name: "Test Author",
-            email: "test@example.com"
+            email: "test@example.com",
           },
-          message: tagMessage
-        }
-      })
+          message: tagMessage,
+        },
+      }),
     } as any;
 
     mockUpsertSlackMessage.mockResolvedValue({
       text: `🏷️ ComfyUI <https://github.com/comfyanonymous/ComfyUI/releases/tag/v0.3.0|Tag v0.3.0> created!\n> ${tagMessage}`,
       channel: "test-channel-id",
-      url: "https://slack.com/message/annotated"
+      url: "https://slack.com/message/annotated",
     });
 
     await runGithubCoreTagNotificationTask();
 
-    expect(mockUpsertSlackMessage).toHaveBeenCalledWith(expect.objectContaining({
-      text: expect.stringContaining(tagMessage),
-    }));
+    expect(mockUpsertSlackMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining(tagMessage),
+      }),
+    );
   });
 
   it("should respect sendSince configuration", async () => {
@@ -249,9 +255,9 @@ describe("GithubCoreTagNotificationTask", () => {
         name: "v0.1.0",
         commit: {
           sha: "old123",
-          url: "https://api.github.com/repos/comfyanonymous/ComfyUI/commits/old123"
-        }
-      }
+          url: "https://api.github.com/repos/comfyanonymous/ComfyUI/commits/old123",
+        },
+      },
     ];
 
     mockGh.repos = {
@@ -259,10 +265,10 @@ describe("GithubCoreTagNotificationTask", () => {
       getCommit: jest.fn().mockResolvedValue({
         data: {
           commit: {
-            author: { date: oldDate.toISOString() }
-          }
-        }
-      })
+            author: { date: oldDate.toISOString() },
+          },
+        },
+      }),
     } as any;
 
     mockGh.git = {
@@ -270,10 +276,10 @@ describe("GithubCoreTagNotificationTask", () => {
         data: {
           tag: "v0.1.0",
           tagger: {
-            date: oldDate.toISOString()
-          }
-        }
-      })
+            date: oldDate.toISOString(),
+          },
+        },
+      }),
     } as any;
 
     await runGithubCoreTagNotificationTask();

--- a/app/tasks/gh-core-tag-notification/index.spec.ts
+++ b/app/tasks/gh-core-tag-notification/index.spec.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it, jest, beforeEach, afterEach } from "bun:test";
+import { gh } from "@/src/gh";
+import { db } from "@/src/db";
+import { getSlackChannel } from "@/src/slack/channels";
+import { upsertSlackMessage } from "../gh-desktop-release-notification/upsertSlackMessage";
+import runGithubCoreTagNotificationTask, { GithubCoreTagNotificationTask } from "./index";
+
+jest.mock("@/src/gh");
+jest.mock("@/src/db");
+jest.mock("@/src/slack/channels");
+jest.mock("../gh-desktop-release-notification/upsertSlackMessage");
+
+describe("GithubCoreTagNotificationTask", () => {
+  const mockGh = gh as jest.Mocked<typeof gh>;
+  const mockGetSlackChannel = getSlackChannel as jest.MockedFunction<typeof getSlackChannel>;
+  const mockUpsertSlackMessage = upsertSlackMessage as jest.MockedFunction<typeof upsertSlackMessage>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    const mockCollection = {
+      createIndex: jest.fn().mockResolvedValue({}),
+      findOne: jest.fn().mockResolvedValue(null),
+      findOneAndUpdate: jest.fn().mockImplementation((_filter, update) =>
+        Promise.resolve(update.$set)
+      ),
+    };
+
+    (GithubCoreTagNotificationTask as any) = mockCollection;
+
+    mockGetSlackChannel.mockResolvedValue({ id: "test-channel-id", name: "desktop" } as any);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should fetch tags from the ComfyUI repository", async () => {
+    const mockTags = [
+      {
+        name: "v0.2.1",
+        commit: {
+          sha: "abc123def456",
+          url: "https://api.github.com/repos/comfyanonymous/ComfyUI/commits/abc123def456"
+        },
+        zipball_url: "https://api.github.com/repos/comfyanonymous/ComfyUI/zipball/v0.2.1",
+        tarball_url: "https://api.github.com/repos/comfyanonymous/ComfyUI/tarball/v0.2.1",
+        node_id: "REF_kwDOI_"
+      }
+    ];
+
+    mockGh.repos = {
+      listTags: jest.fn().mockResolvedValue({ data: mockTags }),
+      getCommit: jest.fn().mockResolvedValue({
+        data: {
+          commit: {
+            author: { date: new Date().toISOString() },
+            committer: { date: new Date().toISOString() }
+          }
+        }
+      })
+    } as any;
+
+    mockGh.git = {
+      getTag: jest.fn().mockRejectedValue(new Error("Not an annotated tag"))
+    } as any;
+
+    mockUpsertSlackMessage.mockResolvedValue({
+      text: "Test message",
+      channel: "test-channel-id",
+      url: "https://slack.com/message/123"
+    });
+
+    await runGithubCoreTagNotificationTask();
+
+    expect(mockGh.repos.listTags).toHaveBeenCalledWith({
+      owner: "comfyanonymous",
+      repo: "ComfyUI",
+      per_page: 10,
+    });
+  });
+
+  it("should save new tags to the database", async () => {
+    const mockTags = [
+      {
+        name: "v0.2.2",
+        commit: {
+          sha: "def789ghi012",
+          url: "https://api.github.com/repos/comfyanonymous/ComfyUI/commits/def789ghi012"
+        }
+      }
+    ];
+
+    mockGh.repos = {
+      listTags: jest.fn().mockResolvedValue({ data: mockTags }),
+      getCommit: jest.fn().mockResolvedValue({
+        data: {
+          commit: {
+            author: { date: new Date().toISOString() }
+          }
+        }
+      })
+    } as any;
+
+    mockGh.git = {
+      getTag: jest.fn().mockResolvedValue({
+        data: {
+          tag: "v0.2.2",
+          tagger: {
+            date: new Date().toISOString(),
+            name: "Test Author",
+            email: "test@example.com"
+          },
+          message: "Release v0.2.2 with new features"
+        }
+      })
+    } as any;
+
+    mockUpsertSlackMessage.mockResolvedValue({
+      text: "Test message",
+      channel: "test-channel-id",
+      url: "https://slack.com/message/456"
+    });
+
+    await runGithubCoreTagNotificationTask();
+
+    expect((GithubCoreTagNotificationTask as any).findOneAndUpdate).toHaveBeenCalled();
+  });
+
+  it("should send Slack notifications for new tags", async () => {
+    const mockTags = [
+      {
+        name: "v0.2.3",
+        commit: {
+          sha: "123abc456def",
+          url: "https://api.github.com/repos/comfyanonymous/ComfyUI/commits/123abc456def"
+        }
+      }
+    ];
+
+    mockGh.repos = {
+      listTags: jest.fn().mockResolvedValue({ data: mockTags }),
+      getCommit: jest.fn().mockResolvedValue({
+        data: {
+          commit: {
+            author: { date: new Date().toISOString() }
+          }
+        }
+      })
+    } as any;
+
+    mockGh.git = {
+      getTag: jest.fn().mockRejectedValue(new Error("Not an annotated tag"))
+    } as any;
+
+    mockUpsertSlackMessage.mockResolvedValue({
+      text: "🏷️ ComfyUI <https://github.com/comfyanonymous/ComfyUI/releases/tag/v0.2.3|Tag v0.2.3> created!",
+      channel: "test-channel-id",
+      url: "https://slack.com/message/789"
+    });
+
+    await runGithubCoreTagNotificationTask();
+
+    expect(mockUpsertSlackMessage).toHaveBeenCalledWith(expect.objectContaining({
+      channel: "test-channel-id",
+      text: expect.stringContaining("v0.2.3"),
+    }));
+  });
+
+  it("should not send duplicate notifications for existing tags", async () => {
+    const mockTags = [
+      {
+        name: "v0.2.0",
+        commit: {
+          sha: "existing123",
+          url: "https://api.github.com/repos/comfyanonymous/ComfyUI/commits/existing123"
+        }
+      }
+    ];
+
+    mockGh.repos = {
+      listTags: jest.fn().mockResolvedValue({ data: mockTags }),
+    } as any;
+
+    (GithubCoreTagNotificationTask as any).findOne.mockResolvedValue({
+      tagName: "v0.2.0",
+      commitSha: "existing123",
+      url: "https://github.com/comfyanonymous/ComfyUI/releases/tag/v0.2.0",
+      slackMessage: {
+        text: "Already sent",
+        channel: "test-channel-id",
+        url: "https://slack.com/message/old"
+      }
+    });
+
+    await runGithubCoreTagNotificationTask();
+
+    expect(mockUpsertSlackMessage).not.toHaveBeenCalled();
+  });
+
+  it("should handle annotated tags with messages", async () => {
+    const mockTags = [
+      {
+        name: "v0.3.0",
+        commit: {
+          sha: "annotated123",
+          url: "https://api.github.com/repos/comfyanonymous/ComfyUI/commits/annotated123"
+        }
+      }
+    ];
+
+    const tagMessage = "Major release with breaking changes";
+
+    mockGh.repos = {
+      listTags: jest.fn().mockResolvedValue({ data: mockTags }),
+    } as any;
+
+    mockGh.git = {
+      getTag: jest.fn().mockResolvedValue({
+        data: {
+          tag: "v0.3.0",
+          tagger: {
+            date: new Date().toISOString(),
+            name: "Test Author",
+            email: "test@example.com"
+          },
+          message: tagMessage
+        }
+      })
+    } as any;
+
+    mockUpsertSlackMessage.mockResolvedValue({
+      text: `🏷️ ComfyUI <https://github.com/comfyanonymous/ComfyUI/releases/tag/v0.3.0|Tag v0.3.0> created!\n> ${tagMessage}`,
+      channel: "test-channel-id",
+      url: "https://slack.com/message/annotated"
+    });
+
+    await runGithubCoreTagNotificationTask();
+
+    expect(mockUpsertSlackMessage).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining(tagMessage),
+    }));
+  });
+
+  it("should respect sendSince configuration", async () => {
+    const oldDate = new Date("2024-01-01T00:00:00Z");
+    const mockTags = [
+      {
+        name: "v0.1.0",
+        commit: {
+          sha: "old123",
+          url: "https://api.github.com/repos/comfyanonymous/ComfyUI/commits/old123"
+        }
+      }
+    ];
+
+    mockGh.repos = {
+      listTags: jest.fn().mockResolvedValue({ data: mockTags }),
+      getCommit: jest.fn().mockResolvedValue({
+        data: {
+          commit: {
+            author: { date: oldDate.toISOString() }
+          }
+        }
+      })
+    } as any;
+
+    mockGh.git = {
+      getTag: jest.fn().mockResolvedValue({
+        data: {
+          tag: "v0.1.0",
+          tagger: {
+            date: oldDate.toISOString()
+          }
+        }
+      })
+    } as any;
+
+    await runGithubCoreTagNotificationTask();
+
+    expect(mockUpsertSlackMessage).not.toHaveBeenCalled();
+  });
+});

--- a/app/tasks/gh-core-tag-notification/index.ts
+++ b/app/tasks/gh-core-tag-notification/index.ts
@@ -81,7 +81,6 @@ async function runGithubCoreTagNotificationTask() {
 
       const tagUrl = `https://github.com/${owner}/${repo}/releases/tag/${tag.name}`;
 
-      let tagDetails;
       let taggerDate;
       let message;
 
@@ -96,8 +95,7 @@ async function runGithubCoreTagNotificationTask() {
           taggerDate = new Date(gitTag.data.tagger.date);
           message = gitTag.data.message;
         }
-      } catch {
-      }
+      } catch {}
 
       let task = await save({
         tagName: tag.name,
@@ -118,7 +116,9 @@ async function runGithubCoreTagNotificationTask() {
           repo,
           ref: tag.commit.sha,
         });
-        const commitDate = new Date(commitData.data.commit.author?.date || commitData.data.commit.committer?.date || new Date());
+        const commitDate = new Date(
+          commitData.data.commit.author?.date || commitData.data.commit.committer?.date || new Date(),
+        );
 
         if (+commitDate < +new Date(config.sendSince)) {
           return task;

--- a/app/tasks/gh-core-tag-notification/index.ts
+++ b/app/tasks/gh-core-tag-notification/index.ts
@@ -1,0 +1,151 @@
+#!/usr/bin/env bun --hot
+import { db } from "@/src/db";
+import { gh } from "@/src/gh";
+import { parseGithubRepoUrl } from "@/src/parseOwnerRepo";
+import { getSlackChannel } from "@/src/slack/channels";
+import DIE from "@snomiao/die";
+import isCI from "is-ci";
+import sflow from "sflow";
+import { upsertSlackMessage } from "../gh-desktop-release-notification/upsertSlackMessage";
+
+/**
+ * GitHub Core Tag Notification Task
+ *
+ * Workflow:
+ * 1. Fetch ComfyUI core repo latest tags
+ * 2. Save the tag info to the database
+ * 3. Notify new tags to slack
+ */
+
+const config = {
+  repo: "https://github.com/comfyanonymous/ComfyUI",
+  slackChannel: "desktop",
+  slackMessage: "🏷️ ComfyUI <{url}|Tag {tagName}> created!",
+  sendSince: new Date("2025-09-24T00:00:00Z").toISOString(),
+  tagsPerPage: 10,
+};
+
+export type GithubCoreTagNotificationTask = {
+  tagName: string;
+  commitSha: string;
+  url: string;
+  createdAt?: Date;
+  taggerDate?: Date;
+  message?: string;
+  slackMessage?: {
+    text: string;
+    channel: string;
+    url?: string;
+  };
+};
+
+export const GithubCoreTagNotificationTask = db.collection<GithubCoreTagNotificationTask>(
+  "GithubCoreTagNotificationTask",
+);
+
+await GithubCoreTagNotificationTask.createIndex({ tagName: 1 }, { unique: true });
+
+const save = async (task: { tagName: string } & Partial<GithubCoreTagNotificationTask>) =>
+  (await GithubCoreTagNotificationTask.findOneAndUpdate(
+    { tagName: task.tagName },
+    { $set: task },
+    { upsert: true, returnDocument: "after" },
+  )) || DIE("never");
+
+if (import.meta.main) {
+  await runGithubCoreTagNotificationTask();
+  if (isCI) {
+    await db.close();
+    process.exit(0);
+  }
+}
+
+async function runGithubCoreTagNotificationTask() {
+  const { owner, repo } = parseGithubRepoUrl(config.repo);
+  const pSlackChannelId = getSlackChannel(config.slackChannel).then(
+    (e) => e.id || DIE(`unable to get slack channel ${config.slackChannel}`),
+  );
+
+  const tags = await gh.repos.listTags({
+    owner,
+    repo,
+    per_page: config.tagsPerPage,
+  });
+
+  await sflow(tags.data)
+    .map(async (tag) => {
+      const existingTask = await GithubCoreTagNotificationTask.findOne({ tagName: tag.name });
+      if (existingTask?.slackMessage?.url) {
+        return existingTask;
+      }
+
+      const tagUrl = `https://github.com/${owner}/${repo}/releases/tag/${tag.name}`;
+
+      let tagDetails;
+      let taggerDate;
+      let message;
+
+      try {
+        const gitTag = await gh.git.getTag({
+          owner,
+          repo,
+          tag_sha: tag.commit.sha,
+        });
+
+        if (gitTag.data.tagger) {
+          taggerDate = new Date(gitTag.data.tagger.date);
+          message = gitTag.data.message;
+        }
+      } catch {
+      }
+
+      let task = await save({
+        tagName: tag.name,
+        commitSha: tag.commit.sha,
+        url: tagUrl,
+        createdAt: new Date(),
+        taggerDate,
+        message,
+      });
+
+      if (task.taggerDate && +task.taggerDate < +new Date(config.sendSince)) {
+        return task;
+      }
+
+      if (!task.taggerDate) {
+        const commitData = await gh.repos.getCommit({
+          owner,
+          repo,
+          ref: tag.commit.sha,
+        });
+        const commitDate = new Date(commitData.data.commit.author?.date || commitData.data.commit.committer?.date || new Date());
+
+        if (+commitDate < +new Date(config.sendSince)) {
+          return task;
+        }
+      }
+
+      const slackChannelId = await pSlackChannelId;
+      const slackMessageText = config.slackMessage
+        .replace("{url}", task.url)
+        .replace("{tagName}", task.tagName)
+        .replace(/$/, task.message ? `\n> ${task.message}` : "");
+
+      if (!task.slackMessage || task.slackMessage.text !== slackMessageText) {
+        task = await save({
+          tagName: task.tagName,
+          slackMessage: await upsertSlackMessage({
+            channel: slackChannelId,
+            text: slackMessageText,
+            url: task.slackMessage?.url,
+          }),
+        });
+      }
+
+      return task;
+    })
+    .log()
+    .run();
+}
+
+export default runGithubCoreTagNotificationTask;

--- a/app/tasks/gh-core-tag-notification/index.ts
+++ b/app/tasks/gh-core-tag-notification/index.ts
@@ -95,7 +95,10 @@ async function runGithubCoreTagNotificationTask() {
           taggerDate = new Date(gitTag.data.tagger.date);
           message = gitTag.data.message;
         }
-      } catch {}
+      } catch {
+        // Silently continue - tag might be lightweight (not annotated)
+        // Lightweight tags don't have tagger info, which is expected
+      }
 
       let task = await save({
         tagName: tag.name,

--- a/app/tasks/run-gh-tasks.ts
+++ b/app/tasks/run-gh-tasks.ts
@@ -8,6 +8,7 @@ import runGithubBountyTask from "./gh-bounty/gh-bounty";
 import { runGithubDesignTask } from "./gh-design/gh-design";
 import runGithubDesktopReleaseNotificationTask from "./gh-desktop-release-notification/index";
 import runGithubFrontendReleaseNotificationTask from "./gh-frontend-release-notification/index";
+import runGithubCoreTagNotificationTask from "./gh-core-tag-notification/index";
 
 const TASKS = [
   {
@@ -25,6 +26,10 @@ const TASKS = [
   {
     name: "GitHub Frontend Release Notification Task",
     run: runGithubFrontendReleaseNotificationTask,
+  },
+  {
+    name: "GitHub Core Tag Notification Task",
+    run: runGithubCoreTagNotificationTask,
   },
   {
     name: "GitHub Bugcop Task",


### PR DESCRIPTION
Attempts to mimic the release monitoring process and do the same for tags in the core repo.

The goal is to ping the desktop channel whenever a new stable version is tagged.