### PR TITLE
refactor: implement lazy Slack client initialization with getSlack() pattern

### DIFF
--- a/app/tasks/gh-design/gh-design.ts
+++ b/app/tasks/gh-design/gh-design.ts
@@ -3,7 +3,7 @@ import { TaskMetaCollection } from "@/src/db/TaskMeta";
 import { gh } from "@/src/gh";
 import { parseIssueUrl } from "@/src/parseIssueUrl";
 import { parseGithubRepoUrl } from "@/src/parseOwnerRepo";
-import { slack } from "@/src/slack";
+import { getSlack } from "@/src/slack";
 import { getSlackChannel } from "@/src/slack/channels";
 import DIE from "@snomiao/die";
 import isCI from "is-ci";
@@ -220,6 +220,7 @@ export async function runGithubDesignTask() {
         if (!task.slackUrl) {
           tlog(`Sending Slack Notification for design task: ${task.url} (${task.type})`);
           if (!dryRun) {
+            const slack = getSlack();
             const msg = await slack.chat.postMessage({
               channel,
               text,
@@ -243,6 +244,7 @@ export async function runGithubDesignTask() {
           if (task.slackMsgHash !== slackMsgHash) {
             tlog(`Updating Slack message for task: ${task.url}`);
             if (!dryRun) {
+              const slack = getSlack();
               await slack.chat.update({
                 ...slackMessageUrlParse(task.slackUrl),
                 text,

--- a/src/postSlackMessage.ts
+++ b/src/postSlackMessage.ts
@@ -1,8 +1,9 @@
 import DIE from "@snomiao/die";
-import { slack } from "./slack";
+import { getSlack } from "./slack";
 
 export async function postSlackMessage(text: string) {
   const channel = process.env.SLACK_BOT_CHANNEL || DIE(new Error("missing env.SLACK_BOT_CHANNEL"));
+  const slack = getSlack();
   // this api will auto retry if failed
   const response = await slack.chat.postMessage({
     channel,

--- a/src/slack/channels.ts
+++ b/src/slack/channels.ts
@@ -1,27 +1,34 @@
 import sflow from "sflow";
-import { slack } from ".";
+import { getSlack, isSlackAvailable } from ".";
 
 if (import.meta.main) {
-  console.log(JSON.stringify(await getSlackChannel("general")))
+  if (isSlackAvailable()) {
+    console.log(JSON.stringify(await getSlackChannel("general")));
+  } else {
+    console.log("Slack token not configured");
+  }
 }
 
 /**
- * 
+ *
  * @author: snomiao <snomiao@gmail.com>
  */
 export async function getSlackChannel(name: string) {
-  return (await sflow(slack.conversations.list({
-    types: "public_channel,private_channel",
-    limit: 1000,
-  }))
-    .map(e => e.channels)
+  const slack = getSlack();
+  return await sflow(
+    slack.conversations.list({
+      types: "public_channel,private_channel",
+      limit: 1000,
+    }),
+  )
+    .map((e) => e.channels)
     .filter()
     .flat()
-    .filter(ch => ch.name === name)
-    .mapAddField('url', ch => `https://slack.com/app_redirect?channel=${ch.id}`)
+    .filter((ch) => ch.name === name)
+    .mapAddField("url", (ch) => `https://slack.com/app_redirect?channel=${ch.id}`)
     // .forEach(channel => {
     //   console.log(`Channel: ${channel.name} (${channel.id})`);
     //   console.log(`URL: ${channel.url}`);
     // })
-    .toAtLeastOne())
-};
+    .toAtLeastOne();
+}

--- a/src/slack/dm.ts
+++ b/src/slack/dm.ts
@@ -1,8 +1,8 @@
 import { upsertSlackMessage } from "@/app/tasks/gh-desktop-release-notification/upsertSlackMessage";
 import DIE from "@snomiao/die";
 import { pageFlow } from "sflow";
-import { slack } from ".";
-import { slackCached } from "./slackCached";
+import { getSlack, isSlackAvailable } from ".";
+import { getSlackCached } from "./slackCached";
 
 // export type SlackWeeklyDM = {
 //     member
@@ -10,55 +10,62 @@ import { slackCached } from "./slackCached";
 // export const SlackWeeklyDM =db.collection
 
 if (import.meta.main) {
-  // await pageFlow(undefined as undefined | string, async (cursor, limit = 100) => {
-  //     const res = await slackCached.conversations.list({  })
-  //     return { data: res.channels, next: res.response_metadata?.next_cursor || null }
-  // }).flat()
-  //     .filter(e => JSON.stringify(e).match('snomiao'))
-  //     .forEach(member => {
-  //         // member.name
-  //         // slack.conversations.list()
-  //     }).log()
-  //     .run()
-  await pageFlow(undefined as undefined | string, async (cursor, limit = 100) => {
-    const res = await slackCached.users.list({ limit: 100, cursor });
-    return { data: res.members, next: res.response_metadata?.next_cursor || null };
-  })
-    .flat()
-    .filter((e) => e.name === "snomiao")
-    // open DM
-    // .by(mapMixins(async member => ({
-    //     a: (await slackCached.conversations.open({
-    //         users: [member.id].join(',') || DIE('fail to get id from member ' + JSON.stringify({ member }))
-    //     }))?.channel || DIE('fail to open conversation to member ' + member.name)
-    // })))
+  if (!isSlackAvailable()) {
+    console.log("Slack token not configured, skipping DM test");
+  } else {
+    const slackCached = getSlackCached();
+    const slack = getSlack();
 
-    // attach channel info to member
-    .mapMixin(async (member) => ({
-      channel:
-        (await slackCached.conversations
-          .open({
-            users: [member.id].join(",") || DIE("fail to get id from member " + JSON.stringify({ member })),
-          })
-          .then((res) => res?.channel)) || DIE("fail to open conversation to member " + member.name),
-    }))
-    // send message
-    .map(async (member) => {
-      const chanId = member.channel.id || DIE("no channel id for " + JSON.stringify({ member }));
-      const lastMessageUrl = await slack.conversations.history({ channel: chanId, limit: 1 }).then(async (res) => {
-        const lastMessage = res.messages?.[0];
-        if (!lastMessage) return;
-        return await slack.chat
-          .getPermalink({
-            channel: chanId,
-            message_ts:
-              lastMessage?.ts || DIE("Got last message without chanId: " + JSON.stringify({ chanId, lastMessage })),
-          })
-          .then((res) => res.permalink || DIE("got empty permalink " + JSON.stringify({ res, chanId, lastMessage })));
-      });
-      await upsertSlackMessage({ channel: member.channel.id, text: "hello", url: lastMessageUrl });
+    // await pageFlow(undefined as undefined | string, async (cursor, limit = 100) => {
+    //     const res = await slackCached.conversations.list({  })
+    //     return { data: res.channels, next: res.response_metadata?.next_cursor || null }
+    // }).flat()
+    //     .filter(e => JSON.stringify(e).match('snomiao'))
+    //     .forEach(member => {
+    //         // member.name
+    //         // slack.conversations.list()
+    //     }).log()
+    //     .run()
+    await pageFlow(undefined as undefined | string, async (cursor, limit = 100) => {
+      const res = await slackCached.users.list({ limit: 100, cursor });
+      return { data: res.members, next: res.response_metadata?.next_cursor || null };
     })
-    // log result
-    .log()
-    .run();
+      .flat()
+      .filter((e) => e.name === "snomiao")
+      // open DM
+      // .by(mapMixins(async member => ({
+      //     a: (await slackCached.conversations.open({
+      //         users: [member.id].join(',') || DIE('fail to get id from member ' + JSON.stringify({ member }))
+      //     }))?.channel || DIE('fail to open conversation to member ' + member.name)
+      // })))
+
+      // attach channel info to member
+      .mapMixin(async (member) => ({
+        channel:
+          (await slackCached.conversations
+            .open({
+              users: [member.id].join(",") || DIE("fail to get id from member " + JSON.stringify({ member })),
+            })
+            .then((res) => res?.channel)) || DIE("fail to open conversation to member " + member.name),
+      }))
+      // send message
+      .map(async (member) => {
+        const chanId = member.channel.id || DIE("no channel id for " + JSON.stringify({ member }));
+        const lastMessageUrl = await slack.conversations.history({ channel: chanId, limit: 1 }).then(async (res) => {
+          const lastMessage = res.messages?.[0];
+          if (!lastMessage) return;
+          return await slack.chat
+            .getPermalink({
+              channel: chanId,
+              message_ts:
+                lastMessage?.ts || DIE("Got last message without chanId: " + JSON.stringify({ chanId, lastMessage })),
+            })
+            .then((res) => res.permalink || DIE("got empty permalink " + JSON.stringify({ res, chanId, lastMessage })));
+        });
+        await upsertSlackMessage({ channel: member.channel.id, text: "hello", url: lastMessageUrl });
+      })
+      // log result
+      .log()
+      .run();
+  }
 }

--- a/src/slack/index.ts
+++ b/src/slack/index.ts
@@ -1,9 +1,35 @@
 import { WebClient } from "@slack/web-api";
-import DIE from "@snomiao/die";
-const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN?.trim() || DIE(("missing env.SLACK_BOT_TOKEN"));
-export const slack = new WebClient(SLACK_BOT_TOKEN);
+
+let slackClient: WebClient | null = null;
+
+export function getSlack(): WebClient {
+  if (!slackClient) {
+    const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN?.trim();
+    if (!SLACK_BOT_TOKEN) {
+      throw new Error("Missing env.SLACK_BOT_TOKEN - Slack functionality is unavailable");
+    }
+    slackClient = new WebClient(SLACK_BOT_TOKEN);
+  }
+  return slackClient;
+}
+
+export function isSlackAvailable(): boolean {
+  return !!process.env.SLACK_BOT_TOKEN?.trim();
+}
+
+export const slack = new Proxy({} as WebClient, {
+  get(_target, prop) {
+    console.warn("Direct access to 'slack' is deprecated. Use getSlack() instead.");
+    const client = getSlack();
+    return (client as any)[prop];
+  },
+});
 
 if (import.meta.main) {
-  await slack.api.test({}); // test token
-  console.log("Slack API token is valid.");
+  if (isSlackAvailable()) {
+    await getSlack().api.test({}); // test token
+    console.log("Slack API token is valid.");
+  } else {
+    console.log("Slack API token not configured.");
+  }
 }


### PR DESCRIPTION
## Summary
- Refactored Slack client initialization to use lazy loading pattern with `getSlack()` function
- Prevents application crashes when `SLACK_BOT_TOKEN` is not configured
- Added `isSlackAvailable()` helper to check if Slack is configured before attempting to use it

## Changes
- **src/slack/index.ts**: Implemented `getSlack()` and `isSlackAvailable()` functions with lazy initialization
- **src/slack/slackCached.ts**: Updated to use `getSlackCached()` pattern for cached client
- Updated all files that import and use the Slack client to use the new pattern
- Added backward compatibility with deprecation warnings for direct access

## Benefits
- Scripts can now import Slack modules without crashing even when token is missing
- Better error handling with clear error messages when Slack is not configured
- Optional Slack functionality - application can run without Slack configured

## Test plan
- [x] Test imports work without SLACK_BOT_TOKEN configured
- [x] Verify getSlack() throws appropriate error when token is missing
- [x] Check isSlackAvailable() correctly detects token presence
- [x] Ensure backward compatibility with deprecation warnings

🤖 Generated with [Claude Code](https://claude.ai/code)