### PR TITLE
feat: refactor comfy-pr CLI to yargs with cpr alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "bin": {
     "comfy-pr": "./src/cli.ts",
+    "cpr": "./src/cli.ts",
     "pr-bot": "./bot/cli.ts",
     "prbot": "./bot/cli.ts"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,40 +1,77 @@
 #!/usr/bin/env bun
-import DIE from "@snomiao/die";
 import { readFile } from "fs/promises";
-import { argv, $ as zx } from "zx";
+import { hideBin } from "yargs/helpers";
+import yargs from "yargs/yargs";
 import { checkComfyActivated } from "./checkComfyActivated";
 import { createComfyRegistryPullRequests } from "./createComfyRegistryPullRequests";
-zx.verbose = true;
 
-if (argv.help) {
-  console.log(
-    `
-  bunx comfy-pr --repolist repos.txt       one repo per-line
-  bunx comfy-pr [...GITHUB_REPO_URLS]      github repos
-  bunx cross-env REPO=https://github.com/OWNER/REPO bunx comfy-pr
-    `.trim(),
-  );
-}
-
-{
-  await checkComfyActivated();
-
+async function resolveRepos(args: {
+  repolist?: string;
+  _: (string | number)[];
+}): Promise<string[]> {
   const envRepos =
     process.env.REPO?.split("\n")
       .map((e) => e.trim())
       .filter(Boolean) || [];
-  const argvRepos = argv._.filter((a) => !a.endsWith(import.meta.filename));
+
+  const argvRepos = args._.map(String).filter(Boolean);
+
   const listRepos =
-    (argv.repolist &&
-      (await readFile(argv.repolist, "utf8").catch(() => ""))
+    (args.repolist &&
+      (await readFile(args.repolist, "utf8").catch(() => ""))
         .split("\n")
         .map((e) => e.trim())
         .filter(Boolean)) ||
     [];
-  const repos = (listRepos.length && listRepos) ||
+
+  const repos =
+    (listRepos.length && listRepos) ||
     (argvRepos.length && argvRepos) ||
-    (envRepos.length && envRepos) || [DIE("Missing PR target, please set env.REPO")];
-  for await (const upstreamUrl of repos) {
-    await createComfyRegistryPullRequests(upstreamUrl);
+    (envRepos.length && envRepos) ||
+    [];
+
+  if (repos.length === 0) {
+    console.error("Error: No repos specified. Provide URLs as args, --repolist, or REPO env var.");
+    process.exit(1);
   }
+  return repos;
 }
+
+const cli = yargs(hideBin(process.argv))
+  .scriptName("cpr")
+  .usage("$0 <command> [options]")
+  .command(
+    "create [repos..]",
+    "Create registry publish PRs for ComfyUI custom nodes",
+    (yargs) =>
+      yargs
+        .positional("repos", {
+          describe: "GitHub repository URLs",
+          type: "string",
+          array: true,
+        })
+        .option("repolist", {
+          alias: "l",
+          type: "string",
+          describe: "File with one repo URL per line",
+        }),
+    async (args) => {
+      await checkComfyActivated();
+      const repos = await resolveRepos({ repolist: args.repolist, _: args.repos || [] });
+      for (const url of repos) {
+        await createComfyRegistryPullRequests(url);
+      }
+    },
+  )
+  .example("$0 create https://github.com/owner/repo", "Create PR for a single repo")
+  .example("$0 create --repolist repos.txt", "Create PRs from a file (one URL per line)")
+  .example("$0 create url1 url2 url3", "Create PRs for multiple repos")
+  .example("REPO=https://github.com/owner/repo $0 create", "Create PR via env variable")
+  .demandCommand(1, "Please specify a command. Run with --help to see available commands.")
+  .strict()
+  .help()
+  .alias("h", "help")
+  .version()
+  .alias("v", "version");
+
+await cli.parse();


### PR DESCRIPTION
## Summary
- Refactor `src/cli.ts` from `zx` argv to `yargs` with proper subcommand handling
- Add `cpr` as a bin alias for `comfy-pr` in package.json
- Running `cpr` with no args shows help with available subcommands
- `cpr create [repos..]` replaces the old positional args pattern
- `cpr create --repolist repos.txt` and `REPO=... cpr create` still work

## Test plan
- [x] `cpr` shows help by default
- [x] `cpr --help` shows usage with examples
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)