### PR TITLE
refactor: rename CLI alias from cpr to cmpr

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "url": "https://github.com/Comfy-Org/Comfy-PR"
   },
   "bin": {
+    "cmpr": "./src/cli.ts",
     "comfy-pr": "./src/cli.ts",
-    "cpr": "./src/cli.ts",
     "pr-bot": "./bot/cli.ts",
     "prbot": "./bot/cli.ts"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,7 +38,7 @@ async function resolveRepos(args: {
 }
 
 const cli = yargs(hideBin(process.argv))
-  .scriptName("cpr")
+  .scriptName("cmpr")
   .usage("$0 <command> [options]")
   .command(
     "create [repos..]",


### PR DESCRIPTION
## Summary
- Rename `cpr` bin alias to `cmpr` (ComfyPR) to avoid confusion with `cp -r`
- Update yargs scriptName accordingly

## Test plan
- [x] `cmpr` shows help
- [x] `cmpr --help` shows usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)