### PR TITLE
fix: use Notion People DB for GitHub→Slack mapping in backport checker

### DIFF
--- a/app/tasks/gh-frontend-backport-checker/index.ts
+++ b/app/tasks/gh-frontend-backport-checker/index.ts
@@ -432,7 +432,8 @@ export async function findSlackUserIdByGithubUsername(
   } catch (e) {
     logger.warn("Failed to look up Notion People mapping, falling back to Slack fuzzy match", {
       githubUsername,
-      error: e,
+      error: (e as Error)?.message ?? String(e),
+      stack: (e as Error)?.stack,
     });
   }
 

--- a/app/tasks/gh-frontend-backport-checker/index.ts
+++ b/app/tasks/gh-frontend-backport-checker/index.ts
@@ -422,19 +422,31 @@ async function getAllSlackMembers() {
  * 2. Falls back to fuzzy matching against Slack display_name, name, and real_name.
  * Returns null if no match found.
  */
+/**
+ * Per-process guard: once Notion People lookup fails, skip it for the rest of
+ * the run so we don't spam the API + logs once per author.
+ */
+let notionPeopleLookupDisabled = false;
+
 export async function findSlackUserIdByGithubUsername(
   githubUsername: string,
 ): Promise<string | null> {
-  try {
-    // Primary: Notion People database (explicit GitHub→Slack mapping)
-    const notionSlackId = await findSlackIdFromNotion(githubUsername);
-    if (notionSlackId) return notionSlackId;
-  } catch (e) {
-    logger.warn("Failed to look up Notion People mapping, falling back to Slack fuzzy match", {
-      githubUsername,
-      error: (e as Error)?.message ?? String(e),
-      stack: (e as Error)?.stack,
-    });
+  if (!notionPeopleLookupDisabled) {
+    try {
+      // Primary: Notion People database (explicit GitHub→Slack mapping)
+      const notionSlackId = await findSlackIdFromNotion(githubUsername);
+      if (notionSlackId) return notionSlackId;
+    } catch (e) {
+      notionPeopleLookupDisabled = true;
+      logger.warn(
+        "Notion People lookup failed; disabling for the rest of this run and falling back to Slack fuzzy match",
+        {
+          githubUsername,
+          error: (e as Error)?.message ?? String(e),
+          stack: (e as Error)?.stack,
+        },
+      );
+    }
   }
 
   try {

--- a/app/tasks/gh-frontend-backport-checker/index.ts
+++ b/app/tasks/gh-frontend-backport-checker/index.ts
@@ -422,10 +422,8 @@ async function getAllSlackMembers() {
  * 2. Falls back to fuzzy matching against Slack display_name, name, and real_name.
  * Returns null if no match found.
  */
-/**
- * Per-process guard: once Notion People lookup fails, skip it for the rest of
- * the run so we don't spam the API + logs once per author.
- */
+// Per-process guard: once Notion People lookup fails, skip it for the rest of
+// the run so we don't spam the API + logs once per author.
 let notionPeopleLookupDisabled = false;
 
 export async function findSlackUserIdByGithubUsername(

--- a/app/tasks/gh-frontend-backport-checker/index.ts
+++ b/app/tasks/gh-frontend-backport-checker/index.ts
@@ -13,6 +13,7 @@ import { ghPageFlow } from "@/src/ghPageFlow";
 import { match as tsmatch } from "ts-pattern";
 import { getChannelInfo } from "@/lib/slack/channel-info";
 import { getSlackChannel } from "@/lib/slack/channels";
+import { findSlackIdByGithubUsername as findSlackIdFromNotion } from "@/lib/notion/people";
 import { slackCached } from "@/lib";
 
 /**
@@ -417,13 +418,26 @@ async function getAllSlackMembers() {
 
 /**
  * Try to find a Slack user ID for a GitHub username.
- * Matches against Slack display_name, name, and real_name (case-insensitive).
+ * 1. First checks the Notion People database for an explicit mapping.
+ * 2. Falls back to fuzzy matching against Slack display_name, name, and real_name.
  * Returns null if no match found.
  */
 export async function findSlackUserIdByGithubUsername(
   githubUsername: string,
 ): Promise<string | null> {
   try {
+    // Primary: Notion People database (explicit GitHub→Slack mapping)
+    const notionSlackId = await findSlackIdFromNotion(githubUsername);
+    if (notionSlackId) return notionSlackId;
+  } catch (e) {
+    logger.warn("Failed to look up Notion People mapping, falling back to Slack fuzzy match", {
+      githubUsername,
+      error: e,
+    });
+  }
+
+  try {
+    // Fallback: fuzzy match against Slack workspace members
     const members = await getAllSlackMembers();
     const lowerGh = githubUsername.toLowerCase();
     const found = members.find((m) => {
@@ -450,16 +464,16 @@ export async function findSlackUserIdByGithubUsername(
 
 /**
  * Resolve who to tag in Slack for a backport notification.
- * Tries the PR author first, falls back to release sheriff.
+ * Tries the PR author first, falls back to release sheriff with a "fallback:" note.
  */
 async function resolveSlackTagForAuthor(githubUsername?: string): Promise<string> {
   if (githubUsername) {
     const slackUserId = await findSlackUserIdByGithubUsername(githubUsername);
     if (slackUserId) return `<@${slackUserId}>`;
   }
-  // Fall back to release sheriff
+  // Fall back to release sheriff — annotate so it's clear this is not the author
   const sheriffId = await getReleaseSheriffUserId();
-  if (sheriffId) return `<@${sheriffId}>`;
+  if (sheriffId) return `_(fallback: <@${sheriffId}>)_`;
   return ""; // no one to tag
 }
 

--- a/app/tasks/gh-issue-transfer-comfyui-to-workflow_templates/index.spec.ts
+++ b/app/tasks/gh-issue-transfer-comfyui-to-workflow_templates/index.spec.ts
@@ -163,7 +163,7 @@ describe("GithubWorkflowTemplatesIssueTransferTask", () => {
 
     // Note: Database verification skipped due to Bun module mocking isolation issues
     // The API interactions above verify the core functionality works correctly
-  });
+  }, 15_000);
 
   it("should skip pull requests", async () => {
     const pullRequest = {

--- a/bot/cli.ts
+++ b/bot/cli.ts
@@ -38,6 +38,7 @@ import yaml from "yaml";
 
 // Notion ability
 import { searchNotion } from "@/lib/notion/search";
+import { fetchPeopleMappings, findSlackIdByGithubUsername } from "@/lib/notion/people";
 
 // Video ability
 import { readVideo } from "@/lib/video/read-video";
@@ -891,6 +892,56 @@ async function main() {
           console.log(`URL: ${r.url}`);
           console.log(`Last edited: ${r.last_edited_time}`);
           console.log("---");
+        }
+      },
+    )
+    .command(
+      "notion people",
+      "List GitHub→Slack mappings from Notion People database",
+      (y) =>
+        y
+          .option("github", {
+            alias: "g",
+            type: "string",
+            description: "Look up a specific GitHub username",
+          })
+          .option("missing", {
+            alias: "m",
+            type: "boolean",
+            description: "Show active members missing a GitHub username",
+            default: false,
+          }),
+      async (args) => {
+        await loadEnvLocal();
+        const mappings = await fetchPeopleMappings();
+
+        if (args.github) {
+          const slackId = await findSlackIdByGithubUsername(args.github);
+          if (slackId) {
+            const entry = mappings.find(
+              (m) => m.githubUsername.toLowerCase() === args.github!.toLowerCase(),
+            );
+            console.log(yaml.stringify({ github: args.github, slackId, person: entry?.person }));
+          } else {
+            console.log(`No mapping found for GitHub username: ${args.github}`);
+            process.exit(1);
+          }
+        } else if (args.missing) {
+          const missing = mappings.filter((m) => !m.inactive && !m.githubUsername && m.slackId);
+          console.log(`Active members without GitHub username: ${missing.length}\n`);
+          console.log(yaml.stringify(missing));
+        } else {
+          const active = mappings.filter((m) => !m.inactive && m.slackId);
+          console.log(`Active people mappings: ${active.length}\n`);
+          console.log(
+            yaml.stringify(
+              active.map((m) => ({
+                person: m.person || "(unnamed)",
+                github: m.githubUsername || "(not set)",
+                slackId: m.slackId,
+              })),
+            ),
+          );
         }
       },
     )

--- a/bot/cli.ts
+++ b/bot/cli.ts
@@ -903,12 +903,12 @@ async function main() {
           .option("github", {
             alias: "g",
             type: "string",
-            description: "Look up a specific GitHub username",
+            describe: "Look up a specific GitHub username",
           })
           .option("missing", {
             alias: "m",
             type: "boolean",
-            description: "Show active members missing a GitHub username",
+            describe: "Show active members missing a GitHub username",
             default: false,
           }),
       async (args) => {

--- a/bot/cli.ts
+++ b/bot/cli.ts
@@ -927,7 +927,7 @@ async function main() {
             process.exit(1);
           }
         } else if (args.missing) {
-          const missing = mappings.filter((m) => !m.inactive && !m.githubUsername && m.slackId);
+          const missing = mappings.filter((m) => !m.inactive && !m.githubUsername);
           console.log(`Active members without GitHub username: ${missing.length}\n`);
           console.log(yaml.stringify(missing));
         } else {

--- a/bun.lock
+++ b/bun.lock
@@ -3750,6 +3750,8 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "fdir/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
     "from2/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],

--- a/lib/notion/people.ts
+++ b/lib/notion/people.ts
@@ -1,0 +1,163 @@
+#!/usr/bin/env bun
+import { Client } from "@notionhq/client";
+import DIE from "@snomiao/die";
+import yaml from "yaml";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+/** Notion People database data source ID */
+const PEOPLE_DS_ID = "2496d73d-3650-801f-9738-000b0f1cbac9";
+
+export interface PersonMapping {
+  person: string;
+  githubUsername: string;
+  slackId: string;
+  inactive: boolean;
+}
+
+/** Cached promise — fetched once per process */
+let peopleMappingsCache: Promise<PersonMapping[]> | null = null;
+
+/**
+ * Fetch all person mappings from the Notion People database.
+ * Results are cached for the lifetime of the process.
+ */
+export function fetchPeopleMappings(): Promise<PersonMapping[]> {
+  if (!peopleMappingsCache) {
+    peopleMappingsCache = fetchPeopleMappingsUncached();
+  }
+  return peopleMappingsCache;
+}
+
+async function fetchPeopleMappingsUncached(): Promise<PersonMapping[]> {
+  const notion = new Client({
+    auth: process.env.NOTION_TOKEN || DIE("missing env.NOTION_TOKEN"),
+  });
+
+  const results: PersonMapping[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const res = await notion.dataSources.query({
+      data_source_id: PEOPLE_DS_ID,
+      result_type: "page",
+      page_size: 100,
+      ...(cursor ? { start_cursor: cursor } : {}),
+    });
+
+    for (const page of res.results) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Notion API returns loosely-typed page objects
+      const props = (page as any).properties; // biome-ignore lint: Notion untyped
+      const person =
+        (props?.["Person"]?.people as Array<{ name: string }> | undefined)
+          ?.map((p) => p.name)
+          .join(", ") || "";
+      const githubUsername =
+        (props?.["GitHub Username"]?.rich_text as Array<{ plain_text: string }> | undefined)
+          ?.map((t) => t.plain_text)
+          .join("") || "";
+      const slackId =
+        (props?.["SlackID"]?.rich_text as Array<{ plain_text: string }> | undefined)
+          ?.map((t) => t.plain_text)
+          .join("") || "";
+      const inactive = (props?.["Inactive"]?.checkbox as boolean) || false;
+
+      results.push({ person, githubUsername, slackId, inactive });
+    }
+
+    cursor = res.next_cursor ?? undefined;
+  } while (cursor);
+
+  return results;
+}
+
+/**
+ * Build a case-insensitive GitHub username → Slack ID map
+ * from the Notion People database. Only includes active members
+ * with both a GitHub username and a Slack ID.
+ */
+export async function getGithubToSlackMap(): Promise<Map<string, string>> {
+  const mappings = await fetchPeopleMappings();
+  const map = new Map<string, string>();
+  for (const m of mappings) {
+    if (!m.inactive && m.githubUsername && m.slackId) {
+      map.set(m.githubUsername.toLowerCase(), m.slackId);
+    }
+  }
+  return map;
+}
+
+/**
+ * Look up a Slack user ID by GitHub username using the Notion People database.
+ * Case-insensitive. Returns null if no mapping found.
+ */
+export async function findSlackIdByGithubUsername(githubUsername: string): Promise<string | null> {
+  const map = await getGithubToSlackMap();
+  return map.get(githubUsername.toLowerCase()) ?? null;
+}
+
+if (import.meta.main) {
+  const argv = await yargs(hideBin(process.argv))
+    .scriptName("notion-people")
+    .usage("$0 [--github <username>] [--all] [--missing]")
+    .option("github", {
+      alias: "g",
+      type: "string",
+      description: "Look up a specific GitHub username",
+    })
+    .option("all", {
+      alias: "a",
+      type: "boolean",
+      description: "List all active mappings",
+      default: false,
+    })
+    .option("missing", {
+      alias: "m",
+      type: "boolean",
+      description: "Show active members missing a GitHub username",
+      default: false,
+    })
+    .example("$0 --github christian-byrne", "Look up a specific user")
+    .example("$0 --all", "List all GitHub→Slack mappings")
+    .example("$0 --missing", "Show members without GitHub usernames")
+    .help()
+    .parse();
+
+  const mappings = await fetchPeopleMappings();
+
+  if (argv.github) {
+    const slackId = await findSlackIdByGithubUsername(argv.github);
+    if (slackId) {
+      const entry = mappings.find(
+        (m) => m.githubUsername.toLowerCase() === argv.github!.toLowerCase(),
+      );
+      console.log(
+        yaml.stringify({
+          github: argv.github,
+          slackId,
+          person: entry?.person,
+        }),
+      );
+    } else {
+      console.log(`No mapping found for GitHub username: ${argv.github}`);
+      process.exit(1);
+    }
+  } else if (argv.missing) {
+    const missing = mappings.filter((m) => !m.inactive && !m.githubUsername && m.slackId);
+    console.log(`Active members without GitHub username: ${missing.length}\n`);
+    console.log(yaml.stringify(missing));
+  } else {
+    // Default: show all active mappings
+    const active = mappings.filter((m) => !m.inactive && m.slackId);
+    console.log(`Active people mappings: ${active.length}\n`);
+    console.log(
+      yaml.stringify(
+        active.map((m) => ({
+          person: m.person,
+          github: m.githubUsername || "(not set)",
+          slackId: m.slackId,
+        })),
+      ),
+    );
+  }
+}

--- a/lib/notion/people.ts
+++ b/lib/notion/people.ts
@@ -1,8 +1,4 @@
-#!/usr/bin/env bun
 import { notion } from "@/lib";
-import yaml from "yaml";
-import yargs from "yargs";
-import { hideBin } from "yargs/helpers";
 
 /** Notion People database data source ID */
 const PEOPLE_DS_ID = "2496d73d-3650-801f-9738-000b0f1cbac9";
@@ -95,70 +91,4 @@ export async function getGithubToSlackMap(): Promise<Map<string, string>> {
 export async function findSlackIdByGithubUsername(githubUsername: string): Promise<string | null> {
   const map = await getGithubToSlackMap();
   return map.get(githubUsername.toLowerCase()) ?? null;
-}
-
-if (import.meta.main) {
-  const argv = await yargs(hideBin(process.argv))
-    .scriptName("notion-people")
-    .usage("$0 [--github <username>] [--all] [--missing]")
-    .option("github", {
-      alias: "g",
-      type: "string",
-      description: "Look up a specific GitHub username",
-    })
-    .option("all", {
-      alias: "a",
-      type: "boolean",
-      description: "List all active mappings",
-      default: false,
-    })
-    .option("missing", {
-      alias: "m",
-      type: "boolean",
-      description: "Show active members missing a GitHub username",
-      default: false,
-    })
-    .example("$0 --github christian-byrne", "Look up a specific user")
-    .example("$0 --all", "List all GitHub→Slack mappings")
-    .example("$0 --missing", "Show members without GitHub usernames")
-    .help()
-    .parse();
-
-  const mappings = await fetchPeopleMappings();
-
-  if (argv.github) {
-    const slackId = await findSlackIdByGithubUsername(argv.github);
-    if (slackId) {
-      const entry = mappings.find(
-        (m) => m.githubUsername.toLowerCase() === argv.github!.toLowerCase(),
-      );
-      console.log(
-        yaml.stringify({
-          github: argv.github,
-          slackId,
-          person: entry?.person,
-        }),
-      );
-    } else {
-      console.log(`No mapping found for GitHub username: ${argv.github}`);
-      process.exit(1);
-    }
-  } else if (argv.missing) {
-    const missing = mappings.filter((m) => !m.inactive && !m.githubUsername && m.slackId);
-    console.log(`Active members without GitHub username: ${missing.length}\n`);
-    console.log(yaml.stringify(missing));
-  } else {
-    // Default: show all active mappings
-    const active = mappings.filter((m) => !m.inactive && m.slackId);
-    console.log(`Active people mappings: ${active.length}\n`);
-    console.log(
-      yaml.stringify(
-        active.map((m) => ({
-          person: m.person,
-          github: m.githubUsername || "(not set)",
-          slackId: m.slackId,
-        })),
-      ),
-    );
-  }
 }

--- a/lib/notion/people.ts
+++ b/lib/notion/people.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env bun
-import { Client } from "@notionhq/client";
-import DIE from "@snomiao/die";
+import { notion } from "@/lib";
 import yaml from "yaml";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
@@ -20,20 +19,20 @@ let peopleMappingsCache: Promise<PersonMapping[]> | null = null;
 
 /**
  * Fetch all person mappings from the Notion People database.
- * Results are cached for the lifetime of the process.
+ * Successful results are cached for the lifetime of the process.
+ * Failed fetches are not cached, so later calls can retry.
  */
 export function fetchPeopleMappings(): Promise<PersonMapping[]> {
   if (!peopleMappingsCache) {
-    peopleMappingsCache = fetchPeopleMappingsUncached();
+    peopleMappingsCache = fetchPeopleMappingsUncached().catch((error) => {
+      peopleMappingsCache = null;
+      throw error;
+    });
   }
   return peopleMappingsCache;
 }
 
 async function fetchPeopleMappingsUncached(): Promise<PersonMapping[]> {
-  const notion = new Client({
-    auth: process.env.NOTION_TOKEN || DIE("missing env.NOTION_TOKEN"),
-  });
-
   const results: PersonMapping[] = [];
   let cursor: string | undefined;
 
@@ -52,14 +51,16 @@ async function fetchPeopleMappingsUncached(): Promise<PersonMapping[]> {
         (props?.["Person"]?.people as Array<{ name: string }> | undefined)
           ?.map((p) => p.name)
           .join(", ") || "";
-      const githubUsername =
+      const githubUsername = (
         (props?.["GitHub Username"]?.rich_text as Array<{ plain_text: string }> | undefined)
           ?.map((t) => t.plain_text)
-          .join("") || "";
-      const slackId =
+          .join("") || ""
+      ).trim();
+      const slackId = (
         (props?.["SlackID"]?.rich_text as Array<{ plain_text: string }> | undefined)
           ?.map((t) => t.plain_text)
-          .join("") || "";
+          .join("") || ""
+      ).trim();
       const inactive = (props?.["Inactive"]?.checkbox as boolean) || false;
 
       results.push({ person, githubUsername, slackId, inactive });

--- a/lib/notion/people.ts
+++ b/lib/notion/people.ts
@@ -3,6 +3,12 @@ import { notion } from "@/lib";
 /** Notion People database data source ID */
 const PEOPLE_DS_ID = "2496d73d-3650-801f-9738-000b0f1cbac9";
 
+interface NotionProp {
+  people?: Array<{ name: string }>;
+  rich_text?: Array<{ plain_text: string }>;
+  checkbox?: boolean;
+}
+
 export interface PersonMapping {
   person: string;
   githubUsername: string;
@@ -12,6 +18,8 @@ export interface PersonMapping {
 
 /** Cached promise — fetched once per process */
 let peopleMappingsCache: Promise<PersonMapping[]> | null = null;
+/** Memoized derived map — built once per successful fetch */
+let githubToSlackMapCache: Promise<Map<string, string>> | null = null;
 
 /**
  * Fetch all person mappings from the Notion People database.
@@ -22,6 +30,7 @@ export function fetchPeopleMappings(): Promise<PersonMapping[]> {
   if (!peopleMappingsCache) {
     peopleMappingsCache = fetchPeopleMappingsUncached().catch((error) => {
       peopleMappingsCache = null;
+      githubToSlackMapCache = null;
       throw error;
     });
   }
@@ -41,23 +50,17 @@ async function fetchPeopleMappingsUncached(): Promise<PersonMapping[]> {
     });
 
     for (const page of res.results) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Notion API returns loosely-typed page objects
-      const props = (page as any).properties; // biome-ignore lint: Notion untyped
-      const person =
-        (props?.["Person"]?.people as Array<{ name: string }> | undefined)
-          ?.map((p) => p.name)
-          .join(", ") || "";
+      const props = (page as { properties?: Record<string, unknown> }).properties as
+        | Record<string, NotionProp>
+        | undefined;
+      const person = props?.["Person"]?.people?.map((p) => p.name).join(", ") || "";
       const githubUsername = (
-        (props?.["GitHub Username"]?.rich_text as Array<{ plain_text: string }> | undefined)
-          ?.map((t) => t.plain_text)
-          .join("") || ""
+        props?.["GitHub Username"]?.rich_text?.map((t) => t.plain_text).join("") || ""
       ).trim();
       const slackId = (
-        (props?.["SlackID"]?.rich_text as Array<{ plain_text: string }> | undefined)
-          ?.map((t) => t.plain_text)
-          .join("") || ""
+        props?.["SlackID"]?.rich_text?.map((t) => t.plain_text).join("") || ""
       ).trim();
-      const inactive = (props?.["Inactive"]?.checkbox as boolean) || false;
+      const inactive = props?.["Inactive"]?.checkbox || false;
 
       results.push({ person, githubUsername, slackId, inactive });
     }
@@ -73,15 +76,24 @@ async function fetchPeopleMappingsUncached(): Promise<PersonMapping[]> {
  * from the Notion People database. Only includes active members
  * with both a GitHub username and a Slack ID.
  */
-export async function getGithubToSlackMap(): Promise<Map<string, string>> {
-  const mappings = await fetchPeopleMappings();
-  const map = new Map<string, string>();
-  for (const m of mappings) {
-    if (!m.inactive && m.githubUsername && m.slackId) {
-      map.set(m.githubUsername.toLowerCase(), m.slackId);
-    }
+export function getGithubToSlackMap(): Promise<Map<string, string>> {
+  if (!githubToSlackMapCache) {
+    githubToSlackMapCache = fetchPeopleMappings()
+      .then((mappings) => {
+        const map = new Map<string, string>();
+        for (const m of mappings) {
+          if (!m.inactive && m.githubUsername && m.slackId) {
+            map.set(m.githubUsername.toLowerCase(), m.slackId);
+          }
+        }
+        return map;
+      })
+      .catch((error) => {
+        githubToSlackMapCache = null;
+        throw error;
+      });
   }
-  return map;
+  return githubToSlackMapCache;
 }
 
 /**


### PR DESCRIPTION
## Problem

The backport checker was falling back to tagging the Release Sheriff (Christian Byrne) for the majority of PRs, even when he wasn't the author. This happened because the fuzzy Slack name matching couldn't resolve most GitHub usernames.

## Solution

- **Primary lookup via Notion People DB**: Added `lib/notion/people.ts` that fetches explicit GitHub Username → Slack ID mappings from the Notion People database (37 active mappings).
- **Graceful fallback**: If Notion lookup fails, falls back to the existing fuzzy Slack name matching.
- **Fallback annotation**: When neither Notion nor fuzzy matching works and the release sheriff is tagged instead, the message now shows `_(fallback: @sheriff)_` to make it clear this is not the PR author.
- **CLI command**: Added `prbot notion people` command with `--github`, `--missing` options to list and verify mappings.

## Verification

- All 76 existing tests pass
- All 37 Notion-mapped GitHub users resolve correctly (case-insensitive)
- `DrJKL` (GitHub) correctly maps to `drJKL` (Notion) → Slack ID