### PR TITLE
fix: only treat DRY_RUN=true as dry-run in upsertSlackMessage

### DIFF
--- a/app/tasks/gh-desktop-release-notification/upsertSlackMessage.ts
+++ b/app/tasks/gh-desktop-release-notification/upsertSlackMessage.ts
@@ -81,7 +81,7 @@ export async function upsertSlackMessage({
   if (!channel) DIE(`No slack channel specified`);
 
   if (!url) {
-    if (process.env.DRY_RUN) {
+    if (process.env.DRY_RUN === "true") {
       console.error("DRY RUN MODE");
       console.error("sending text:", text);
       throw new Error(chalk.red("Sending slack message to: " + JSON.stringify({ channel })));
@@ -99,7 +99,7 @@ export async function upsertSlackMessage({
     const url = slackMessageUrlStringify({ channel, ts: msg.ts! });
     return { ...msg, url, text, channel };
   }
-  if (process.env.DRY_RUN) {
+  if (process.env.DRY_RUN === "true") {
     console.error("DRY RUN MODE");
     console.error("sending text:", text);
     throw new Error(chalk.red("Updating slack message to: " + JSON.stringify({ channel, url })));
@@ -150,7 +150,7 @@ export async function upsertSlackMarkdownMessage({
   if (!channel) DIE(`No slack channel specified`);
 
   if (!url) {
-    if (process.env.DRY_RUN) {
+    if (process.env.DRY_RUN === "true") {
       console.error("DRY RUN MODE");
       console.error("sending markdown:", markdown);
       throw new Error(chalk.red("Sending slack message to: " + JSON.stringify({ channel })));
@@ -173,7 +173,7 @@ export async function upsertSlackMarkdownMessage({
     const url = slackMessageUrlStringify({ channel, ts: msg.ts! });
     return { ...msg, url, text: markdown, channel };
   }
-  if (process.env.DRY_RUN) {
+  if (process.env.DRY_RUN === "true") {
     console.error("DRY RUN MODE");
     console.error("sending markdown:", markdown);
     throw new Error(chalk.red("Updating slack message to: " + JSON.stringify({ channel, url })));


### PR DESCRIPTION
## Summary
- Scheduled run https://github.com/Comfy-Org/Comfy-PR/actions/runs/24166391135 failed because GitHub Design / Desktop Release Notification / Frontend Release Notification tasks threw `Sending slack message to: ...`.
- Root cause: `if (process.env.DRY_RUN)` is truthy for the string `"false"`, so the dry-run guard fired even on schedule runs (where the workflow sets `DRY_RUN=false`).
- Fix: compare to the literal string `"true"`, matching the convention used in `run-gh-tasks.ts`, `gh-bugcop.tsx`, and `gh-design.ts`.

## Test plan
- [ ] Next scheduled `gh-combined-tasks` run posts release/design notifications without throwing