### PR TITLE
feat: add unified 'prbot read <url>' command for Slack & Notion URLs

### DIFF
--- a/bot/cli.ts
+++ b/bot/cli.ts
@@ -39,6 +39,10 @@ import yaml from "yaml";
 // Notion ability
 import { searchNotion } from "@/lib/notion/search";
 import { fetchPeopleMappings, findSlackIdByGithubUsername } from "@/lib/notion/people";
+import { readNotionPage } from "@/lib/notion/read-page";
+
+// URL parsing
+import { parseUrl } from "@/lib/url/parseUrl";
 
 // Video ability
 import { readVideo } from "@/lib/video/read-video";
@@ -287,6 +291,72 @@ async function main() {
           head: args.head as string | undefined,
           prompt: args.prompt as string,
         });
+      },
+    )
+    .command(
+      "read <url>",
+      "Read any supported URL (Slack message/channel/file, Notion page) and output content as YAML",
+      (y) =>
+        y.positional("url", {
+          type: "string",
+          describe: "URL to read (Slack or Notion)",
+          demandOption: true,
+        }),
+      async (args) => {
+        await loadEnvLocal();
+
+        const url = args.url as string;
+        const parsed = parseUrl(url);
+
+        switch (parsed.type) {
+          case "slack-message": {
+            const messages = await readNearbyMessages(parsed.channel!, parsed.ts!, 20, 20);
+            console.log(yaml.stringify(messages));
+            break;
+          }
+
+          case "slack-channel": {
+            const messages = await readRecentMessages(parsed.channel!, 10);
+            console.log(yaml.stringify(messages));
+            break;
+          }
+
+          case "slack-file": {
+            if (!parsed.fileId) {
+              console.error("Could not extract file ID from URL");
+              process.exit(1);
+            }
+            const fileInfo = await getSlackFileInfo(parsed.fileId);
+            const fileName = fileInfo.name || `file-${parsed.fileId}`;
+            const outputPath = `./${fileName}`;
+            await downloadSlackFile(parsed.fileId, outputPath);
+            console.log(
+              yaml.stringify({
+                type: "file_downloaded",
+                file_id: parsed.fileId,
+                file_name: fileName,
+                file_size: fileInfo.size,
+                downloaded_to: outputPath,
+              }),
+            );
+            break;
+          }
+
+          case "notion-page": {
+            const page = await readNotionPage(parsed.notionPageId!);
+            console.log(yaml.stringify(page));
+            break;
+          }
+
+          default:
+            console.error(`Unsupported URL: ${url}`);
+            console.error("Supported formats:");
+            console.error("  Slack message: https://workspace.slack.com/archives/C123/p1234567890");
+            console.error("  Slack channel: https://workspace.slack.com/archives/C123");
+            console.error("  Slack file:    https://files.slack.com/files-pri/T123-F456/file.pdf");
+            console.error("  Notion page:   https://www.notion.so/workspace/Page-Title-<id>");
+            process.exit(1);
+        }
       },
     )
     .command("slack", "Slack integration commands", (yargs) => {
@@ -1230,6 +1300,8 @@ async function main() {
     .epilog(
       [
         "Examples:",
+        "  prbot read 'https://workspace.slack.com/archives/C123/p1234567890'  # Slack message",
+        "  prbot read 'https://www.notion.so/my-workspace/Page-Title-abc123'   # Notion page",
         "  prbot code pr -r Comfy-Org/ComfyUI -b main -p 'Fix auth bug'",
         "  prbot code search -q 'binarization' --repo Comfy-Org/ComfyUI",
         "  prbot github-issue search -q 'authentication bug' -l 5",

--- a/lib/notion/read-page.ts
+++ b/lib/notion/read-page.ts
@@ -1,0 +1,209 @@
+#!/usr/bin/env bun
+import { notion } from "@/lib";
+import sflow from "sflow";
+import yaml from "yaml";
+
+/**
+ * Read a Notion page's content by page ID or URL
+ * Usage: bun lib/notion/read-page.ts <notion-url-or-page-id>
+ */
+
+/** Extracts a page ID from a Notion URL, returns null if not a Notion URL. Raw UUIDs pass through. */
+export function parseNotionUrl(url: string): string | null {
+  const uuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (uuidRe.test(url)) return url;
+
+  const bare32 = /^[0-9a-f]{32}$/i;
+  if (bare32.test(url)) return formatUuid(url);
+
+  try {
+    const parsed = new URL(url);
+    if (!parsed.hostname.endsWith("notion.so") && !parsed.hostname.endsWith("notion.site"))
+      return null;
+
+    // Extract last 32 hex chars from the pathname
+    const match = parsed.pathname.match(/([0-9a-f]{32})\s*$/i);
+    if (match) return formatUuid(match[1]);
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+function formatUuid(hex: string): string {
+  const h = hex.replace(/-/g, "");
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`;
+}
+
+type RichText = { plain_text: string; annotations?: Annotations; href?: string | null };
+type Annotations = {
+  bold?: boolean;
+  italic?: boolean;
+  strikethrough?: boolean;
+  code?: boolean;
+};
+
+function richTextToMarkdown(richTexts: RichText[]): string {
+  return richTexts
+    .map((rt) => {
+      let text = rt.plain_text;
+      const a = rt.annotations;
+      if (a?.code) text = `\`${text}\``;
+      if (a?.bold) text = `**${text}**`;
+      if (a?.italic) text = `*${text}*`;
+      if (a?.strikethrough) text = `~~${text}~~`;
+      if (rt.href) text = `[${text}](${rt.href})`;
+      return text;
+    })
+    .join("");
+}
+
+function blockToMarkdown(block: Record<string, unknown>, indent = ""): string {
+  const type = block.type as string;
+  const data = block[type] as Record<string, unknown> | undefined;
+  const rich = (data?.rich_text as RichText[]) ?? [];
+  const text = richTextToMarkdown(rich);
+
+  switch (type) {
+    case "paragraph":
+      return `${indent}${text}`;
+    case "heading_1":
+      return `${indent}# ${text}`;
+    case "heading_2":
+      return `${indent}## ${text}`;
+    case "heading_3":
+      return `${indent}### ${text}`;
+    case "bulleted_list_item":
+      return `${indent}- ${text}`;
+    case "numbered_list_item":
+      return `${indent}1. ${text}`;
+    case "to_do": {
+      const checked = (data?.checked as boolean) ? "x" : " ";
+      return `${indent}- [${checked}] ${text}`;
+    }
+    case "toggle":
+      return `${indent}<details><summary>${text}</summary></details>`;
+    case "code": {
+      const lang = (data?.language as string) || "";
+      return `${indent}\`\`\`${lang}\n${text}\n${indent}\`\`\``;
+    }
+    case "quote":
+      return text
+        .split("\n")
+        .map((l) => `${indent}> ${l}`)
+        .join("\n");
+    case "callout": {
+      const icon = (data?.icon as Record<string, unknown>)?.emoji ?? "";
+      return `${indent}> ${icon} ${text}`;
+    }
+    case "divider":
+      return `${indent}---`;
+    case "image": {
+      const img = data as Record<string, unknown>;
+      const caption = richTextToMarkdown((img?.caption as RichText[]) ?? []);
+      const fileData = (img?.file ?? img?.external) as Record<string, unknown> | undefined;
+      const url = (fileData?.url as string) ?? "";
+      return `${indent}![${caption || "image"}](${url})`;
+    }
+    case "bookmark": {
+      const url = (data?.url as string) ?? "";
+      const caption = richTextToMarkdown((data?.caption as RichText[]) ?? []);
+      return `${indent}[${caption || url}](${url})`;
+    }
+    case "link_preview": {
+      const url = (data?.url as string) ?? "";
+      return `${indent}[${url}](${url})`;
+    }
+    case "table":
+      return ""; // table rows are children, handled during recursion
+    case "table_row": {
+      const cells = (data?.cells as RichText[][]) ?? [];
+      const row = cells.map((cell) => richTextToMarkdown(cell)).join(" | ");
+      return `${indent}| ${row} |`;
+    }
+    default:
+      return `${indent}[unsupported: ${type}]`;
+  }
+}
+
+async function fetchBlockChildren(
+  blockId: string,
+  indent = "",
+): Promise<string[]> {
+  const lines: string[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const resp = await notion.blocks.children.list({
+      block_id: blockId,
+      start_cursor: cursor,
+      page_size: 100,
+    });
+
+    for (const block of resp.results as Array<Record<string, unknown>>) {
+      const md = blockToMarkdown(block, indent);
+      if (md) lines.push(md);
+
+      // For tables, insert header separator after first row
+      if ((block as Record<string, unknown>).type === "table") {
+        const children = await fetchBlockChildren(block.id as string, indent);
+        if (children.length > 0) {
+          lines.push(children[0]);
+          const colCount = (children[0].match(/\|/g)?.length ?? 1) - 1;
+          lines.push(`${indent}| ${Array(colCount).fill("---").join(" | ")} |`);
+          lines.push(...children.slice(1));
+        }
+      } else if ((block as Record<string, unknown>).has_children) {
+        const children = await fetchBlockChildren(block.id as string, indent + "  ");
+        lines.push(...children);
+      }
+    }
+
+    cursor = resp.has_more ? (resp.next_cursor ?? undefined) : undefined;
+  } while (cursor);
+
+  return lines;
+}
+
+function extractTitle(page: Record<string, unknown>): string {
+  const properties = page.properties as Record<string, unknown> | undefined;
+  if (!properties) return "Untitled";
+
+  const titleProp = Object.values(properties).find(
+    (prop: unknown) => (prop as Record<string, unknown>).type === "title",
+  ) as Record<string, unknown> | undefined;
+
+  const titleArr = titleProp?.title as RichText[] | undefined;
+  if (titleArr?.[0]?.plain_text) return titleArr[0].plain_text;
+  return "Untitled";
+}
+
+export async function readNotionPage(pageId: string): Promise<{
+  title: string;
+  url: string;
+  last_edited_time: string;
+  content: string;
+}> {
+  const page = (await notion.pages.retrieve({ page_id: pageId })) as Record<string, unknown>;
+  const title = extractTitle(page);
+  const url = page.url as string;
+  const last_edited_time = page.last_edited_time as string;
+
+  const contentLines = await fetchBlockChildren(pageId);
+  const content = contentLines.join("\n\n");
+
+  return { title, url, last_edited_time, content };
+}
+
+if (import.meta.main) {
+  const input = process.argv[2];
+  if (!input) {
+    console.error("Usage: bun lib/notion/read-page.ts <notion-url-or-page-id>");
+    process.exit(1);
+  }
+
+  const pageId = parseNotionUrl(input) ?? input;
+  const result = await readNotionPage(pageId);
+  console.log(yaml.stringify(result));
+}

--- a/lib/url/parseUrl.ts
+++ b/lib/url/parseUrl.ts
@@ -1,0 +1,73 @@
+import { parseSlackUrlSmart } from "../slack/parseSlackUrlSmart";
+import { parseNotionUrl } from "../notion/read-page";
+
+export type ParsedUrlType = "slack-message" | "slack-channel" | "slack-file" | "notion-page" | "unknown";
+
+export interface ParsedUrl {
+  type: ParsedUrlType;
+  url: string;
+  // Slack fields
+  channel?: string;
+  ts?: string;
+  fileId?: string;
+  // Notion fields
+  notionPageId?: string;
+}
+
+export function parseUrl(url: string): ParsedUrl {
+  try {
+    const urlObj = new URL(url);
+
+    // Check for Notion URLs
+    if (urlObj.hostname.includes("notion.so") || urlObj.hostname.includes("notion.site")) {
+      const pageId = parseNotionUrl(url);
+      return {
+        type: pageId ? "notion-page" : "unknown",
+        url,
+        notionPageId: pageId ?? undefined,
+      };
+    }
+
+    // Check for Slack URLs
+    if (
+      urlObj.hostname.includes("slack.com") ||
+      urlObj.hostname === "files.slack.com"
+    ) {
+      const parsed = parseSlackUrlSmart(url);
+      const typeMap = {
+        message: "slack-message",
+        channel: "slack-channel",
+        file: "slack-file",
+        unknown: "unknown",
+      } as const;
+
+      return {
+        type: typeMap[parsed.type],
+        url,
+        channel: parsed.channel,
+        ts: parsed.ts,
+        fileId: parsed.fileId,
+      };
+    }
+  } catch {
+    // Invalid URL, fall through to unknown
+  }
+
+  return { type: "unknown", url };
+}
+
+if (import.meta.main) {
+  const url = process.argv[2];
+
+  if (!url) {
+    console.error("Usage: bun lib/url/parseUrl.ts <url>");
+    console.error("\nExamples:");
+    console.error("  Slack message: bun lib/url/parseUrl.ts 'https://workspace.slack.com/archives/C123/p1234567890'");
+    console.error("  Slack channel: bun lib/url/parseUrl.ts 'https://workspace.slack.com/archives/C123'");
+    console.error("  Notion page:   bun lib/url/parseUrl.ts 'https://www.notion.so/my-page-abc123def456'");
+    process.exit(1);
+  }
+
+  const result = parseUrl(url);
+  console.log(JSON.stringify(result, null, 2));
+}


### PR DESCRIPTION
Adds a top-level `prbot read <url>` command that auto-detects URL type and reads content:

- **Slack messages** → nearby messages (20 before/after)
- **Slack channels** → recent 10 messages
- **Slack files** → download locally
- **Notion pages** → fetch page metadata + render all blocks to markdown

### New files
- `lib/notion/read-page.ts` — Notion page reader (recursive block fetcher → markdown)
- `lib/url/parseUrl.ts` — unified URL type detector (Slack/Notion)

### Modified
- `bot/cli.ts` — new `read <url>` top-level command

### Usage
```bash
prbot read 'https://workspace.slack.com/archives/C123/p1234567890'
prbot read 'https://www.notion.so/workspace/Page-Title-abc123def456'
```