### PR TITLE
fix(gh-design): skip self-review requests and tolerate 422 errors

### DIFF
--- a/app/tasks/gh-design/filterReviewers.spec.ts
+++ b/app/tasks/gh-design/filterReviewers.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { filterReviewers } from "./gh-design";
+
+describe("filterReviewers", () => {
+  const REVIEWERS = ["PabloWiedemann", "AliceDev"];
+
+  it("excludes the PR author from both lists", () => {
+    const result = filterReviewers(REVIEWERS, "PabloWiedemann");
+    expect(result.requestReviewers).toEqual(["AliceDev"]);
+    expect(result.newReviewers).toEqual(["AliceDev"]);
+  });
+
+  it("returns all reviewers when author is not in the list", () => {
+    const result = filterReviewers(REVIEWERS, "SomeoneElse");
+    expect(result.requestReviewers).toEqual(["PabloWiedemann", "AliceDev"]);
+    expect(result.newReviewers).toEqual(["PabloWiedemann", "AliceDev"]);
+  });
+
+  it("excludes already-requested reviewers from newReviewers only", () => {
+    const result = filterReviewers(REVIEWERS, "SomeoneElse", ["PabloWiedemann"]);
+    expect(result.requestReviewers).toEqual(["PabloWiedemann", "AliceDev"]);
+    expect(result.newReviewers).toEqual(["AliceDev"]);
+  });
+
+  it("returns empty newReviewers when all are already requested", () => {
+    const result = filterReviewers(REVIEWERS, "SomeoneElse", ["PabloWiedemann", "AliceDev"]);
+    expect(result.requestReviewers).toEqual(["PabloWiedemann", "AliceDev"]);
+    expect(result.newReviewers).toEqual([]);
+  });
+
+  it("returns empty lists when author is the only reviewer", () => {
+    const result = filterReviewers(["PabloWiedemann"], "PabloWiedemann");
+    expect(result.requestReviewers).toEqual([]);
+    expect(result.newReviewers).toEqual([]);
+  });
+
+  it("handles undefined alreadyRequested as no-one requested yet", () => {
+    const result = filterReviewers(REVIEWERS, "SomeoneElse", undefined);
+    expect(result.newReviewers).toEqual(["PabloWiedemann", "AliceDev"]);
+  });
+});

--- a/app/tasks/gh-design/filterReviewers.spec.ts
+++ b/app/tasks/gh-design/filterReviewers.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { filterReviewers } from "./gh-design";
+import { filterReviewers } from "./filterReviewers";
 
 describe("filterReviewers", () => {
   const REVIEWERS = ["PabloWiedemann", "AliceDev"];

--- a/app/tasks/gh-design/filterReviewers.spec.ts
+++ b/app/tasks/gh-design/filterReviewers.spec.ts
@@ -38,4 +38,14 @@ describe("filterReviewers", () => {
     const result = filterReviewers(REVIEWERS, "SomeoneElse", undefined);
     expect(result.newReviewers).toEqual(["PabloWiedemann", "AliceDev"]);
   });
+
+  it("compares usernames case-insensitively", () => {
+    const result = filterReviewers(REVIEWERS, "pablowiedemann");
+    expect(result.requestReviewers).toEqual(["AliceDev"]);
+  });
+
+  it("matches already-requested reviewers case-insensitively", () => {
+    const result = filterReviewers(REVIEWERS, "SomeoneElse", ["pablowiedemann"]);
+    expect(result.newReviewers).toEqual(["AliceDev"]);
+  });
 });

--- a/app/tasks/gh-design/filterReviewers.ts
+++ b/app/tasks/gh-design/filterReviewers.ts
@@ -1,0 +1,13 @@
+/**
+ * Filter the reviewer list for a PR: excludes the PR author and
+ * anyone who has already been requested.
+ */
+export function filterReviewers(
+  allReviewers: string[],
+  prAuthor: string,
+  alreadyRequested?: string[],
+): { requestReviewers: string[]; newReviewers: string[] } {
+  const requestReviewers = allReviewers.filter((e) => e !== prAuthor);
+  const newReviewers = requestReviewers.filter((e) => !alreadyRequested?.includes(e));
+  return { requestReviewers, newReviewers };
+}

--- a/app/tasks/gh-design/filterReviewers.ts
+++ b/app/tasks/gh-design/filterReviewers.ts
@@ -1,13 +1,16 @@
 /**
  * Filter the reviewer list for a PR: excludes the PR author and
  * anyone who has already been requested.
+ * GitHub usernames are case-insensitive, so comparisons are normalized.
  */
 export function filterReviewers(
   allReviewers: string[],
   prAuthor: string,
   alreadyRequested?: string[],
 ): { requestReviewers: string[]; newReviewers: string[] } {
-  const requestReviewers = allReviewers.filter((e) => e !== prAuthor);
-  const newReviewers = requestReviewers.filter((e) => !alreadyRequested?.includes(e));
+  const normalizedAuthor = prAuthor.toLowerCase();
+  const normalizedRequested = new Set(alreadyRequested?.map((r) => r.toLowerCase()) ?? []);
+  const requestReviewers = allReviewers.filter((e) => e.toLowerCase() !== normalizedAuthor);
+  const newReviewers = requestReviewers.filter((e) => !normalizedRequested.has(e.toLowerCase()));
   return { requestReviewers, newReviewers };
 }

--- a/app/tasks/gh-design/filterReviewers.ts
+++ b/app/tasks/gh-design/filterReviewers.ts
@@ -1,6 +1,7 @@
 /**
- * Filter the reviewer list for a PR: excludes the PR author and
- * anyone who has already been requested.
+ * Compute eligible reviewers for a PR.
+ * Returns `requestReviewers` (all reviewers minus the PR author) and
+ * `newReviewers` (eligible reviewers not yet requested).
  * GitHub usernames are case-insensitive, so comparisons are normalized.
  */
 export function filterReviewers(

--- a/app/tasks/gh-design/gh-design.ts
+++ b/app/tasks/gh-design/gh-design.ts
@@ -273,8 +273,9 @@ export async function runGithubDesignTask() {
                   reviewers: newReviewers,
                 });
               } catch (err: any) {
-                // GitHub returns 422 when the requested reviewer is the PR author
-                // or otherwise cannot be added. Record the attempt to avoid
+                // GitHub may return 422 when a requested reviewer cannot be added,
+                // such as when they are not a collaborator, cannot be requested,
+                // or have already been requested. Record the attempt to avoid
                 // retrying on every 5-minute schedule run.
                 if (err?.status !== 422) throw err;
                 tlog(`Reviewer request rejected (422): ${err.message}`);

--- a/app/tasks/gh-design/gh-design.ts
+++ b/app/tasks/gh-design/gh-design.ts
@@ -21,6 +21,7 @@ import {
   planDesignCommentNotification,
 } from "./slackNotifications";
 import { slackMessageUrlParse, slackMessageUrlStringify } from "./slackMessageUrlParse";
+import { filterReviewers } from "./filterReviewers";
 const tlog = createTimeLogger();
 
 /**
@@ -94,20 +95,6 @@ type GithubDesignTask = {
   lastRunAt?: Date; // last time this item was processed
   lastDoneAt?: Date | null; // last time this item was processed successfuly
 };
-
-/**
- * Filter the reviewer list for a PR: excludes the PR author and
- * anyone who has already been requested.
- */
-export function filterReviewers(
-  allReviewers: string[],
-  prAuthor: string,
-  alreadyRequested?: string[],
-): { requestReviewers: string[]; newReviewers: string[] } {
-  const requestReviewers = allReviewers.filter((e) => e !== prAuthor);
-  const newReviewers = requestReviewers.filter((e) => !alreadyRequested?.includes(e));
-  return { requestReviewers, newReviewers };
-}
 
 // task states
 const COLLECTION_NAME = "GithubDesignTask";
@@ -268,18 +255,15 @@ export async function runGithubDesignTask() {
           });
 
       if (task.state === "open") {
-        if (
-          task.type === "pull_request" &&
-          REQUEST_REVIEWERS.some((e) => !task.reviewers?.includes(e))
-        ) {
+        if (task.type === "pull_request") {
           const { requestReviewers, newReviewers } = filterReviewers(
             REQUEST_REVIEWERS,
             task.user,
             task.reviewers,
           );
-          tlog(`Requesting reviewers: ${newReviewers.join(", ") || "(none)"}`);
-          if (!dryRun) {
-            if (newReviewers.length > 0) {
+          if (newReviewers.length > 0) {
+            tlog(`Requesting reviewers: ${newReviewers.join(", ")}`);
+            if (!dryRun) {
               try {
                 await gh.pulls.requestReviewers({
                   owner,
@@ -296,8 +280,8 @@ export async function runGithubDesignTask() {
                 if (status !== 422) throw err;
                 tlog(`Reviewer request rejected (422): ${err}`);
               }
+              task = await saveGithubDesignTask(url, { reviewers: requestReviewers });
             }
-            task = await saveGithubDesignTask(url, { reviewers: requestReviewers });
           }
         }
 

--- a/app/tasks/gh-design/gh-design.ts
+++ b/app/tasks/gh-design/gh-design.ts
@@ -264,6 +264,7 @@ export async function runGithubDesignTask() {
           if (newReviewers.length > 0) {
             tlog(`Requesting reviewers: ${newReviewers.join(", ")}`);
             if (!dryRun) {
+              let reviewersRequested = false;
               try {
                 await gh.pulls.requestReviewers({
                   owner,
@@ -271,6 +272,7 @@ export async function runGithubDesignTask() {
                   pull_number: issue_number,
                   reviewers: newReviewers,
                 });
+                reviewersRequested = true;
               } catch (err: unknown) {
                 // GitHub may return 422 when a requested reviewer cannot be added,
                 // such as when they are not a collaborator, cannot be requested,
@@ -280,7 +282,9 @@ export async function runGithubDesignTask() {
                 if (status !== 422) throw err;
                 tlog(`Reviewer request rejected (422): ${err}`);
               }
-              task = await saveGithubDesignTask(url, { reviewers: requestReviewers });
+              if (reviewersRequested) {
+                task = await saveGithubDesignTask(url, { reviewers: requestReviewers });
+              }
             }
           }
         }

--- a/app/tasks/gh-design/gh-design.ts
+++ b/app/tasks/gh-design/gh-design.ts
@@ -275,9 +275,9 @@ export async function runGithubDesignTask() {
                 reviewersRequested = true;
               } catch (err: unknown) {
                 // GitHub may return 422 when a requested reviewer cannot be added,
-                // such as when they are not a collaborator, cannot be requested,
-                // or have already been requested. Record the attempt to avoid
-                // retrying on every 5-minute schedule run.
+                // such as when they are not a collaborator or cannot be requested.
+                // We log but don't persist, so the request will be retried on the
+                // next run (the reviewer may become eligible later).
                 const status = (err as { status?: number })?.status;
                 if (status !== 422) throw err;
                 tlog(`Reviewer request rejected (422): ${err}`);

--- a/app/tasks/gh-design/gh-design.ts
+++ b/app/tasks/gh-design/gh-design.ts
@@ -95,6 +95,20 @@ type GithubDesignTask = {
   lastDoneAt?: Date | null; // last time this item was processed successfuly
 };
 
+/**
+ * Filter the reviewer list for a PR: excludes the PR author and
+ * anyone who has already been requested.
+ */
+export function filterReviewers(
+  allReviewers: string[],
+  prAuthor: string,
+  alreadyRequested?: string[],
+): { requestReviewers: string[]; newReviewers: string[] } {
+  const requestReviewers = allReviewers.filter((e) => e !== prAuthor);
+  const newReviewers = requestReviewers.filter((e) => !alreadyRequested?.includes(e));
+  return { requestReviewers, newReviewers };
+}
+
 // task states
 const COLLECTION_NAME = "GithubDesignTask";
 export const GithubDesignTaskMeta = TaskMetaCollection(COLLECTION_NAME, githubDesignTaskMetaSchema);
@@ -258,9 +272,10 @@ export async function runGithubDesignTask() {
           task.type === "pull_request" &&
           REQUEST_REVIEWERS.some((e) => !task.reviewers?.includes(e))
         ) {
-          const requestReviewers = REQUEST_REVIEWERS.filter((e) => e !== task.user);
-          const newReviewers = requestReviewers.filter(
-            (e) => !task.reviewers?.includes(e),
+          const { requestReviewers, newReviewers } = filterReviewers(
+            REQUEST_REVIEWERS,
+            task.user,
+            task.reviewers,
           );
           tlog(`Requesting reviewers: ${newReviewers.join(", ") || "(none)"}`);
           if (!dryRun) {

--- a/app/tasks/gh-design/gh-design.ts
+++ b/app/tasks/gh-design/gh-design.ts
@@ -258,9 +258,9 @@ export async function runGithubDesignTask() {
           task.type === "pull_request" &&
           REQUEST_REVIEWERS.some((e) => !task.reviewers?.includes(e))
         ) {
-          const requestReviewers = REQUEST_REVIEWERS;
+          const requestReviewers = REQUEST_REVIEWERS.filter((e) => e !== task.user);
           const newReviewers = requestReviewers.filter(
-            (e) => !task.reviewers?.includes(e) && e !== task.user,
+            (e) => !task.reviewers?.includes(e),
           );
           tlog(`Requesting reviewers: ${newReviewers.join(", ") || "(none)"}`);
           if (!dryRun) {
@@ -272,13 +272,14 @@ export async function runGithubDesignTask() {
                   pull_number: issue_number,
                   reviewers: newReviewers,
                 });
-              } catch (err: any) {
+              } catch (err: unknown) {
                 // GitHub may return 422 when a requested reviewer cannot be added,
                 // such as when they are not a collaborator, cannot be requested,
                 // or have already been requested. Record the attempt to avoid
                 // retrying on every 5-minute schedule run.
-                if (err?.status !== 422) throw err;
-                tlog(`Reviewer request rejected (422): ${err.message}`);
+                const status = (err as { status?: number })?.status;
+                if (status !== 422) throw err;
+                tlog(`Reviewer request rejected (422): ${err}`);
               }
             }
             task = await saveGithubDesignTask(url, { reviewers: requestReviewers });

--- a/app/tasks/gh-design/gh-design.ts
+++ b/app/tasks/gh-design/gh-design.ts
@@ -259,15 +259,27 @@ export async function runGithubDesignTask() {
           REQUEST_REVIEWERS.some((e) => !task.reviewers?.includes(e))
         ) {
           const requestReviewers = REQUEST_REVIEWERS;
-          const newReviewers = requestReviewers.filter((e) => !task.reviewers?.includes(e));
-          tlog(`Requesting reviewers: ${newReviewers.join(", ")}`);
+          const newReviewers = requestReviewers.filter(
+            (e) => !task.reviewers?.includes(e) && e !== task.user,
+          );
+          tlog(`Requesting reviewers: ${newReviewers.join(", ") || "(none)"}`);
           if (!dryRun) {
-            await gh.pulls.requestReviewers({
-              owner,
-              repo,
-              pull_number: issue_number,
-              reviewers: newReviewers,
-            });
+            if (newReviewers.length > 0) {
+              try {
+                await gh.pulls.requestReviewers({
+                  owner,
+                  repo,
+                  pull_number: issue_number,
+                  reviewers: newReviewers,
+                });
+              } catch (err: any) {
+                // GitHub returns 422 when the requested reviewer is the PR author
+                // or otherwise cannot be added. Record the attempt to avoid
+                // retrying on every 5-minute schedule run.
+                if (err?.status !== 422) throw err;
+                tlog(`Reviewer request rejected (422): ${err.message}`);
+              }
+            }
             task = await saveGithubDesignTask(url, { reviewers: requestReviewers });
           }
         }


### PR DESCRIPTION
## Summary

The 5-minute [`Combined GitHub Tasks`](https://github.com/Comfy-Org/Comfy-PR/actions/runs/24778612522) workflow has been failing every run. Root cause:

```
GitHub Design Task: 21128ms - Review cannot be requested from pull request author.
1 task(s) failed. Exiting with error code 1.
```

`REQUEST_REVIEWERS` is hardcoded to `["PabloWiedemann"]` in `app/tasks/gh-design/gh-design.ts`. When Pablo opens a PR himself, the task calls `gh.pulls.requestReviewers` with him as the reviewer, GitHub responds **422 Review cannot be requested from pull request author**, and `run-gh-tasks.ts` then exits non-zero — turning one avoidable PR-level error into a full workflow failure on every 5-minute tick.

## Fix

- **Skip self-review**: filter the PR author (`task.user`) out of the reviewer list before calling the API (case-insensitive comparison).
- **Tolerate 422**: wrap the call in a try/catch that swallows only `status === 422` (non-collaborators, etc.), rethrowing anything else. 422s are retried on subsequent runs since the condition may be transient.
- **Persist only on success**: reviewer list is saved to DB only after a successful API call, keeping DB state accurate.
- **No redundant retries**: the guard condition uses the filtered `newReviewers` list, so when all eligible reviewers are already requested, the block is skipped entirely.
- **Extracted `filterReviewers()`** into a side-effect-free module with 8 unit tests covering author filtering, case insensitivity, and edge cases.

## Test plan

- [x] CI `run_comfy_pr` and `run_combined_github_tasks` pass
- [x] `filterReviewers.spec.ts` — 8 tests passing
- [ ] Next scheduled `Combined GitHub Tasks` run finishes green.
- [ ] PRs by non-authors still get reviewer requests as before.
- [ ] PRs authored by a `REQUEST_REVIEWERS` member skip the call silently.