### PR TITLE
feat(backport-checker): distinguish merged from released

### DIFF
--- a/app/tasks/gh-frontend-backport-checker/index.ts
+++ b/app/tasks/gh-frontend-backport-checker/index.ts
@@ -16,6 +16,7 @@ import { getSlackChannel } from "@/lib/slack/channels";
 import { findSlackIdByGithubUsername as findSlackIdFromNotion } from "@/lib/notion/people";
 import { slackCached } from "@/lib";
 import { getReleaseComparison } from "./releaseComparison";
+import { isCommitInTag, isTagOnLine, resolveShippedStatus } from "./releasedStatus";
 
 /**
  * GitHub Frontend Backport Checker Task
@@ -200,7 +201,13 @@ const config = {
   slackChannelName: "frontend-releases",
 };
 
-export type BackportStatus = "not-needed" | "needed" | "in-progress" | "completed" | "unknown";
+export type BackportStatus =
+  | "not-needed"
+  | "needed"
+  | "in-progress"
+  | "completed"
+  | "merged-unreleased"
+  | "unknown";
 
 // track each bugfix PR backport status
 export type GithubFrontendBackportCheckerTask = {
@@ -231,6 +238,9 @@ export type GithubFrontendBackportCheckerTask = {
         prNumber?: number;
         prTitle?: string;
         prStatus?: "open" | "closed" | "merged";
+        // The cherry-picked commit on the release branch. The source SHA never
+        // lands there, so tag containment must be tested against this one.
+        mergeCommitSha?: string | null;
         lastCheckedAt?: Date;
       }[];
     }>;
@@ -360,6 +370,8 @@ export function getBackportStatusEmoji(status: BackportStatus): string {
       return ":pr-merged:";
     case "in-progress":
       return ":pr-open:";
+    case "merged-unreleased":
+      return "**:rotating_light: Merged, not released**";
     case "needed":
       return "**:exclamation: Need backport**";
     case "not-needed":
@@ -369,6 +381,46 @@ export function getBackportStatusEmoji(status: BackportStatus): string {
     default:
       return "⚪";
   }
+}
+
+/**
+ * Newest tag on `branch` that already contains `commitSha`, or null when the
+ * commit sits past every tag — merged onto the release line but never shipped.
+ */
+const tagListCache = new Map<string, Promise<{ name: string }[]>>();
+
+function listTagsCached(owner: string, repo: string): Promise<{ name: string }[]> {
+  const key = `${owner}/${repo}`;
+  const cached = tagListCache.get(key);
+  if (cached) return cached;
+  const pending = ghPageFlow(ghc.repos.listTags, { per_page: 100 })({ owner, repo }).toArray();
+  tagListCache.set(key, pending);
+  return pending;
+}
+
+async function findReleaseTagContaining(
+  owner: string,
+  repo: string,
+  branch: string,
+  commitSha: string,
+): Promise<string | null> {
+  const tags = await listTagsCached(owner, repo);
+  const branchTags = tags.filter((t) => isTagOnLine(t.name, branch));
+  if (!branchTags.length) return null;
+
+  for (const tag of branchTags) {
+    const comparison = await ghc.repos
+      .compareCommits({ owner, repo, base: tag.name, head: commitSha })
+      .then((e) => e.data)
+      .catch((error: unknown) => {
+        // Reporting a shipped fix as unreleased is a false alarm, so a failed
+        // comparison must be visible rather than silently negative.
+        logger.warn(`compareCommits ${tag.name}...${commitSha.slice(0, 10)} failed`, { error });
+        return null;
+      });
+    if (comparison && isCommitInTag(comparison.status)) return tag.name;
+  }
+  return null;
 }
 
 export function middleTruncated(maxLength: number, str: string): string {
@@ -646,6 +698,7 @@ async function processTask(
                     prNumber?: number;
                     prTitle?: string;
                     prStatus?: "open" | "closed" | "merged";
+                    mergeCommitSha?: string | null;
                     lastCheckedAt?: Date;
                   }[],
                 };
@@ -665,6 +718,7 @@ async function processTask(
                 prNumber?: number;
                 prTitle?: string;
                 prStatus?: "open" | "closed" | "merged";
+                mergeCommitSha?: string | null;
                 lastCheckedAt?: Date;
               }[] = [];
               const status: BackportStatus = await tsmatch(comparing.status)
@@ -688,6 +742,7 @@ async function processTask(
                     prNumber: bpr.number,
                     prTitle: bpr.title,
                     prStatus: bpr.merged_at ? "merged" : bpr.state === "open" ? "open" : "closed",
+                    mergeCommitSha: bpr.merged_at ? bpr.merge_commit_sha : null,
                     lastCheckedAt: new Date(),
                   }));
 
@@ -710,7 +765,7 @@ async function processTask(
 
           // Determine overall backport status (ignoring "not-needed" targets)
           const activeTargets = backportTargetStatus.filter((t) => t.status !== "not-needed");
-          const backportStatus: BackportStatus =
+          const mergedStatus: BackportStatus =
             activeTargets.length && activeTargets.every((t) => t.status === "completed")
               ? "completed"
               : activeTargets.some((t) => t.status === "in-progress")
@@ -721,6 +776,31 @@ async function processTask(
                     ? "not-needed" // all targets have backport-not-needed labels
                     : "unknown";
 
+          // Landing on the release branch is not reaching users: resolve which
+          // tag, if any, actually carries the commit on every completed target.
+          const releasedInTag =
+            mergedStatus === "completed"
+              ? await sflow(backportTargetStatus.filter((t) => t.status === "completed"))
+                  .map(async ({ branch, prs }) => {
+                    // A cherry-picked backport has a different SHA on the release
+                    // branch; testing the source SHA would report every backport
+                    // as unreleased.
+                    const shaOnBranch =
+                      prs.find((pr) => pr.prStatus === "merged" && pr.mergeCommitSha)
+                        ?.mergeCommitSha ?? commitSha;
+                    return await findReleaseTagContaining(owner, repo, branch, shaOnBranch);
+                  })
+                  .toArray()
+                  .then((tags) =>
+                    tags.every((t) => t !== null) ? tags.filter(Boolean).join(", ") : null,
+                  )
+              : null;
+
+          const backportStatus = resolveShippedStatus({
+            backportStatus: mergedStatus,
+            releasedInTag,
+          });
+          // Save to database
           return {
             commitSha,
             commitMessage,
@@ -765,7 +845,11 @@ async function processTask(
       ? ("not-mentioned" as const)
       : e.backportTargetStatus.some((t) => t.status !== "completed" && t.status !== "not-needed")
         ? ("in-progress" as const)
-        : ("completed" as const),
+        : // Every target merged, but no tag carries it — the 1.47.10 state, which
+          // read as fully done right up until users reported the unfixed bug.
+          e.backportStatus === "merged-unreleased"
+          ? ("merged-unreleased" as const)
+          : ("completed" as const),
   }));
 
   // - generate report based on commits, note: slack's markdown not support table
@@ -780,6 +864,19 @@ ${
     .map((bf) => {
       const tag = bf.prAuthor ? authorTags.get(bf.prAuthor) || "" : "";
       return `[${middleTruncated(60, bf.commitMessage)}](${bf.prUrl}) ➡️ _❗ Might need backport_ ${tag}`.trim();
+    })
+    .join("\n")
+}
+${
+  // merged everywhere but not in any tag — needs a patch release, not a backport
+  statuses
+    .filter((e) => e.status === "merged-unreleased")
+    .map((bf) => {
+      const tag = bf.prAuthor ? authorTags.get(bf.prAuthor) || "" : "";
+      const branches = bf.backportTargetStatus.map((t) => t.branch).join(", ");
+      return `[${middleTruncated(60, bf.commitMessage)}](${bf.prUrl}) ➡️ ${getBackportStatusEmoji(
+        "merged-unreleased",
+      )} on ${branches} — cut a patch release ${tag}`.trim();
     })
     .join("\n")
 }

--- a/app/tasks/gh-frontend-backport-checker/releasedStatus.spec.ts
+++ b/app/tasks/gh-frontend-backport-checker/releasedStatus.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import { isCommitInTag, isTagOnLine, resolveShippedStatus } from "./releasedStatus";
+
+describe("isCommitInTag", () => {
+  it("treats a commit contained by the tag as released", () => {
+    // compareCommits(base: tag, head: commit): the commit is an ancestor of the
+    // tag, so the tag already carries it.
+    expect(isCommitInTag("identical")).toBe(true);
+    expect(isCommitInTag("behind")).toBe(true);
+  });
+
+  it("treats a commit past the tag as unreleased", () => {
+    expect(isCommitInTag("ahead")).toBe(false);
+    expect(isCommitInTag("diverged")).toBe(false);
+  });
+});
+
+describe("resolveShippedStatus", () => {
+  it("reports merged-unreleased when the backport landed but no tag carries it", () => {
+    // The exact 1.47.10 state: #14065 merged onto core/1.47 after v1.47.10 was cut.
+    expect(resolveShippedStatus({ backportStatus: "completed", releasedInTag: null })).toBe(
+      "merged-unreleased",
+    );
+  });
+
+  it("reports completed once a tag carries the commit", () => {
+    expect(resolveShippedStatus({ backportStatus: "completed", releasedInTag: "v1.47.11" })).toBe(
+      "completed",
+    );
+  });
+
+  it("leaves a still-unmerged backport alone", () => {
+    expect(resolveShippedStatus({ backportStatus: "needed", releasedInTag: null })).toBe("needed");
+    expect(resolveShippedStatus({ backportStatus: "in-progress", releasedInTag: null })).toBe(
+      "in-progress",
+    );
+  });
+});
+
+describe("isTagOnLine", () => {
+  it("matches tags on the same release line", () => {
+    expect(isTagOnLine("v1.47.11", "core/1.47")).toBe(true);
+    expect(isTagOnLine("cloud/v1.47.7", "cloud/1.47")).toBe(true);
+  });
+
+  it("does not let a shorter line swallow a longer one", () => {
+    // core/1.4 must not match v1.40.0 — that would mark an unrelated line shipped.
+    expect(isTagOnLine("v1.40.0", "core/1.4")).toBe(false);
+    expect(isTagOnLine("v1.470.0", "core/1.47")).toBe(false);
+  });
+
+  it("rejects tags from other lines", () => {
+    expect(isTagOnLine("v1.48.5", "core/1.47")).toBe(false);
+  });
+});

--- a/app/tasks/gh-frontend-backport-checker/releasedStatus.ts
+++ b/app/tasks/gh-frontend-backport-checker/releasedStatus.ts
@@ -1,0 +1,39 @@
+import type { BackportStatus } from "./index";
+
+/**
+ * A merged backport is not a shipped fix.
+ *
+ * #14065 merged onto core/1.47 nineteen hours after v1.47.10 was tagged. This
+ * checker reported it "completed", ComfyUI pinned v1.47.10, and the fix reached
+ * nobody for a week while five users reported the bug it had already fixed.
+ * Tracking only "did it land on the branch" is what made that invisible.
+ */
+
+/**
+ * Given `compareCommits({ base: tag, head: commit })`, whether the tag already
+ * contains the commit.
+ */
+export function isCommitInTag(comparisonStatus: string): boolean {
+  return comparisonStatus === "identical" || comparisonStatus === "behind";
+}
+
+/**
+ * Whether a tag belongs to a release line. Exact match or a dot-delimited
+ * prefix only: a bare startsWith lets `core/1.4` swallow `v1.40.0`.
+ */
+export function isTagOnLine(tagName: string, branch: string): boolean {
+  const branchVersion = branch.replace(/^(core|cloud)\//, "");
+  const tagVersion = tagName.replace(/^(cloud\/)?v/, "");
+  return tagVersion === branchVersion || tagVersion.startsWith(`${branchVersion}.`);
+}
+
+export function resolveShippedStatus({
+  backportStatus,
+  releasedInTag,
+}: {
+  backportStatus: BackportStatus;
+  releasedInTag: string | null;
+}): BackportStatus {
+  if (backportStatus !== "completed") return backportStatus;
+  return releasedInTag ? "completed" : "merged-unreleased";
+}


### PR DESCRIPTION
The checker marks a bugfix `completed` the moment its backport merges onto the release branch. That is precisely the state that misled us last week.

#14065 merged onto `core/1.47` nineteen hours after `v1.47.10` was tagged. The checker said completed, ComfyUI pinned `1.47.10`, and the fix reached nobody for a week while five users reported the bug it had already fixed.

## Change

- Resolve which tag, if any, actually contains each backported commit
- New `merged-unreleased` status, rendered in the Slack report as "Merged, not released"
- `completed` now means a published tag carries it

A backport is a cherry-pick, so the source commit never appears on the release branch. Containment is tested against the backport PR's own `merge_commit_sha`; testing the source SHA would have reported every backport as unreleased.

## Notes

New logic is a separate pure module (`releasedStatus.ts`) with an imported spec, written test-first. The existing spec re-declares its regexes locally rather than importing them, so it cannot catch drift in the real values. Worth fixing separately.

Release-line matching is exact or dot-delimited, so `core/1.4` cannot match `v1.40.0`. Failed comparisons log a warning rather than silently counting as unreleased, since a false "not shipped" is the worst outcome for this check. `listTags` is cached per repo instead of refetched per commit per branch.

The blocking guard for this failure mode lives in ComfyUI_frontend CI (Comfy-Org/ComfyUI_frontend#14429) rather than here, since a safety check should not depend on a long-running bot process. This change is the visibility half.
